### PR TITLE
Shorten generated text to 255 characters to avoid MySQL column overflow.

### DIFF
--- a/lib/tasks/test_data.rake
+++ b/lib/tasks/test_data.rake
@@ -299,8 +299,8 @@ namespace :db do
 
       puts "INVENTING SOME BOGUS FAQS"
       40.times do
-        Faq.create(question: BetterLorem.w(5 + rand(10), true, true) + "?",
-                   answer: BetterLorem.p(1 + rand(4), true, false),
+        Faq.create(question: BetterLorem.w(5 + rand(10), true, true)[0,255] + "?",
+                   answer: BetterLorem.p(1 + rand(4), true, false)[0,255],
                    enabled: true,
                    locale: 'de')
       end


### PR DESCRIPTION
Test Data generation sometimes crashes when the randomly generated faq and answers are too long for the corresponding MySQL columns. 
