### PR TITLE
Update github urls after the move to teikei organization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/sjockers/teikei.svg?branch=master)](https://travis-ci.org/sjockers/teikei) [![Code Climate](https://codeclimate.com/github/sjockers/teikei.png)](https://codeclimate.com/github/sjockers/teikei) [![Dependency Status](https://www.versioneye.com/user/projects/52e534e8ec13750d0c0001ba/badge.png)](https://www.versioneye.com/user/projects/52e534e8ec13750d0c0001ba)
+[![Build Status](https://travis-ci.org/teikei/teikei.svg?branch=master)](https://travis-ci.org/teikei/teikei) [![Code Climate](https://codeclimate.com/github/teikei/teikei.png)](https://codeclimate.com/github/teikei/teikei) [![Dependency Status](https://www.versioneye.com/user/projects/52e534e8ec13750d0c0001ba/badge.png)](https://www.versioneye.com/user/projects/52e534e8ec13750d0c0001ba)
 
 # Teikei
 

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -4,7 +4,7 @@ ActiveAdmin.register_page "Dashboard" do
 
   content :title => proc{ I18n.t("active_admin.dashboard") } do
     panel "Teikei" do
-      para %(Currently deployed: #{`git describe --tags --abbrev=0`}, #{link_to(`git rev-parse --short HEAD`, "https://github.com/sjockers/teikei/commit/#{`git rev-parse HEAD`}")}).html_safe
+      para %(Currently deployed: #{`git describe --tags --abbrev=0`}, #{link_to(`git rev-parse --short HEAD`, "https://github.com/teikei/teikei/commit/#{`git rev-parse HEAD`}")}).html_safe
     end
     columns do
       column do

--- a/app/templates/text_blocks/terms.de.html.haml
+++ b/app/templates/text_blocks/terms.de.html.haml
@@ -24,7 +24,7 @@
     %h3 4. Ernte teilen ist Open Source Software
     %p
       Der Quellcode von ernte-teilen.org ist Open Source. Das bedeutet, dass ihn jeder einsehen, verbessern und unter bestimmten Umständen wiederverwenden kann. Dabei gelten die Regeln der GNU Affero General Public License Version 3. Den Quellcode findest du auf
-      %a{href: 'https://github.com/sjockers/teikei'} GitHub.
+      %a{href: 'https://github.com/teikei/teikei'} GitHub.
 
     %hr
 


### PR DESCRIPTION
closes #29
