### PR TITLE
README.md: swap 'Installing/updating' and 'Prerequisites' sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ You need to create an `.env` file which contains the environment variables neede
 
 Unlike most classic Rails projects, this application uses separate package management for its client-side dependencies. In order to build the front-end of this application, you will need [bower][bower] in addition to Bundler. Bower will install all external client-side packages into the `/vendor/assets/bower_components` folder.
 
-#### Installing/updating dependencies:
-
-1. Run `bundle install` (installs Ruby dependencies)
-2. Run `bower install` (installs client-side dependencies)
-
 #### Prerequisites for using bower:
 
 - a working [node.js][nodejs] installation
 - a global installation of [Bower][bower]: `npm install -g bower`
+
+#### Installing/updating dependencies:
+
+1. Run `bundle install` (installs Ruby dependencies)
+2. Run `bower install` (installs client-side dependencies)
 
 ### Test data
 


### PR DESCRIPTION
This makes the text follow the natural flow of installation instructions.
