### PR TITLE
Final touches for marker clustering

### DIFF
--- a/app/assets/javascripts/apps/places/views/map.js
+++ b/app/assets/javascripts/apps/places/views/map.js
@@ -137,7 +137,7 @@ Teikei.module("Places", function(Places, Teikei, Backbone, Marionette, $, _) {
 
     initMarkerLayer: function(markers) {
       var markerGroup = new L.MarkerClusterGroup({
-        maxClusterRadius: 120,
+        maxClusterRadius: 50,
         iconCreateFunction: function (cluster) {
           var markers = cluster.getAllChildMarkers();
           var clusterView = new Places.MarkerCluster({markers: markers});

--- a/app/assets/javascripts/apps/places/views/marker_cluster.js
+++ b/app/assets/javascripts/apps/places/views/marker_cluster.js
@@ -1,7 +1,7 @@
 Teikei.module('Places', function(Places, Teikei, Backbone, Marionette, $, _) {
 
-  var BASE_DIAMETER = 80;
-  var FACTOR = 2.5;
+  var BASE_DIAMETER = 70;
+  var FACTOR = 1.1;
 
   Places.MarkerCluster = Marionette.ItemView.extend({
 

--- a/app/assets/stylesheets/common/_base.css.scss
+++ b/app/assets/stylesheets/common/_base.css.scss
@@ -21,7 +21,9 @@ $desktop: 960px 12;
 
 // Applying "border-box" box-sizing model to every element on the page.
 *, *:before, *:after {
-  @include border-box-sizing;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 body {

--- a/app/assets/templates/places/map_item.jst.ejs
+++ b/app/assets/templates/places/map_item.jst.ejs
@@ -6,5 +6,10 @@
         <%= translatedProducts() %>
     </p>
     <button class="details" title="Öffnet die Details dieses Eintrags">Details</button>
-    <button class="network" title="Visualisiert verbundene Höfe und Gruppen">Netzwerk anzeigen</button>
+
+    <%
+    // The network visualisation is currently disabled due to incompatibilities with Leaflet.markercluster.
+    // TODO: update network vis and re-enable network visualisation (see next line)
+    // <button class="network" title="Visualisiert verbundene Höfe und Gruppen">Netzwerk anzeigen</button>
+    %>
 </div>


### PR DESCRIPTION
Improve the marker cluster presentation and temporarily disable the network view.

Closes #45.