### PR TITLE
Feature: Add Postcode field and cleanup city field

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -59,7 +59,7 @@
     "@casl/ability": "^2.4.2",
     "@crudlio/crudl": "https://github.com/crudlio/crudl.git",
     "@crudlio/crudl-connectors-base": "https://github.com/crudlio/crudl-connectors-base.git",
-    "lodash": "4.17.10",
+    "lodash": "4.17.11",
     "moment": "2.22.2",
     "prop-types": "15.6.2",
     "react": "16.4.2",

--- a/api/db/migrations/20190126145045_postcode_street_housenumber_fields.js
+++ b/api/db/migrations/20190126145045_postcode_street_housenumber_fields.js
@@ -1,0 +1,20 @@
+exports.up = (knex, Promise) =>
+  Promise.all([
+    knex.schema.table('farms', table => {
+      table.string('postalcode')
+      table.string('street')
+      table.string('housenumber')
+    }),
+    knex.schema.table('depots', table => {
+      table.string('postalcode')
+      table.string('street')
+      table.string('housenumber')
+    }),
+    knex.schema.table('initiatives', table => {
+      table.string('postalcode')
+      table.string('street')
+      table.string('housenumber')
+    })
+  ])
+
+exports.down = (knex, Promise) => {}

--- a/api/package.json
+++ b/api/package.json
@@ -42,6 +42,7 @@
     "pretty-quick": "npx pretty-quick --staged",
     "prettier": "npx prettier **/*.js --write",
     "migrate:latest": "cd db && npx knex migrate:latest",
+    "migrate:make": "cd db && npx knex migrate:make",
     "seed:run": "cd db && npx knex seed:run",
     "test:init": "cd db && NODE_ENV=test npx babel-node index.js init | npx pino-pretty --translateTime",
     "test:drop": "cd db && NODE_ENV=test npx babel-node index.js drop | npx pino-pretty --translateTime"

--- a/api/package.json
+++ b/api/package.json
@@ -80,7 +80,7 @@
     "joi": "13.6.0",
     "jwt-decode": "2.2.0",
     "knex": "0.15.2",
-    "lodash": "4.17.10",
+    "lodash": "4.17.11",
     "nodemailer": "4.6.8",
     "nodemailer-sparkpost-transport": "2.1.0",
     "nunjucks": "3.1.4",

--- a/api/src/app.js
+++ b/api/src/app.js
@@ -24,8 +24,8 @@ const app = express(feathers())
 app.disable('x-powered-by')
 app.configure(express.rest())
 
-app.configure(logger)
 app.configure(envHelpers())
+app.configure(logger)
 
 const conf = configuration()
 app.configure(conf)

--- a/api/src/hooks/authorization.js
+++ b/api/src/hooks/authorization.js
@@ -50,6 +50,7 @@ const defineAbilities = ctx => {
 
   const WRITABLE_DEPOT_ATTRIBUTES = [
     'name',
+    'postalcode',
     'city',
     'state',
     'country',
@@ -71,6 +72,7 @@ const defineAbilities = ctx => {
 
   const WRITABLE_FARM_ATTRIBUTES = [
     'name',
+    'postalcode',
     'city',
     'state',
     'country',
@@ -100,6 +102,7 @@ const defineAbilities = ctx => {
 
   const WRITABLE_INITIATIVE_ATTRIBUTES = [
     'name',
+    'postalcode',
     'city',
     'state',
     'country',

--- a/api/src/hooks/logger.js
+++ b/api/src/hooks/logger.js
@@ -4,7 +4,7 @@ import logger from 'feathers-logger'
 export const appLogger = pino()
 
 export default app => {
-  appLogger.level = process.env.NODE_ENV === 'DEVELOPMENT' ? 'debug' : 'warn'
+  appLogger.level = app.isDevelopment() ? 'debug' : 'info'
   app.configure(logger(appLogger))
 }
 
@@ -14,7 +14,8 @@ export const loggerHook = context => {
   app.info(`${type} app.service('${path}').${method}()`)
 
   if (typeof toJSON === 'function') {
-    app.debug(context, 'context')
+    const { arguments: args } = context
+    app.debug('arguments', args)
   }
 
   if (error) {

--- a/api/src/hooks/relations.js
+++ b/api/src/hooks/relations.js
@@ -11,6 +11,7 @@ const qualify = (model, attribute) =>
 export const entryColumns = model => [
   qualify(model, 'id'),
   'name',
+  'postalcode',
   'city',
   'state',
   'country',

--- a/api/src/models/validation/joi/entry.js
+++ b/api/src/models/validation/joi/entry.js
@@ -18,6 +18,9 @@ export const entry = {
   housenumber: Joi.string()
     .max(255)
     .trim(),
+  postalcode: Joi.string()
+    .max(255)
+    .trim(),
   city: Joi.string()
     .max(255)
     .trim()

--- a/api/src/models/validation/joi/entry.js
+++ b/api/src/models/validation/joi/entry.js
@@ -9,6 +9,15 @@ export const entry = {
     .max(255)
     .trim()
     .required(),
+  state: Joi.string()
+    .max(255)
+    .trim(),
+  street: Joi.string()
+    .max(255)
+    .trim(),
+  housenumber: Joi.string()
+    .max(255)
+    .trim(),
   city: Joi.string()
     .max(255)
     .trim()

--- a/api/src/queues/reverseGeocode.js
+++ b/api/src/queues/reverseGeocode.js
@@ -29,18 +29,21 @@ export default app => {
     const entry = await app
       .service(`/admin/${service}`)
       .get(id, { paginate: false })
-    if (!entry.country || !entry.state) {
-      const position = await app
-        .service('reverseGeocoder')
-        .create({ latitude: entry.latitude, longitude: entry.longitude })
-      await app
-        .service(`/admin/${service}`)
-        .patch(
-          id,
-          { country: position.country, state: position.state },
-          { paginate: false }
-        )
-    }
+    const position = await app
+      .service('reverseGeocoder')
+      .create({ latitude: entry.latitude, longitude: entry.longitude })
+    await app.service(`/admin/${service}`).patch(
+      id,
+      {
+        country: position.country,
+        state: position.state,
+        city: position.city,
+        postalcode: position.postalCode,
+        street: position.street,
+        housenumber: position.houseNumber
+      },
+      { paginate: false }
+    )
     job.progress(100)
   })
 
@@ -56,7 +59,7 @@ export default app => {
         .find({ paginate: false })
       app.info(`found ${entities.length} ${service} records`)
       entities.forEach(e => {
-        if (!e.country && !e.state) {
+        if ((!e.country && !e.state) || !e.postalcode || !e.street) {
           app.info(
             service,
             `adding ${service} record with id ${e.id} to geocoder queue`

--- a/api/src/queues/reverseGeocode.js
+++ b/api/src/queues/reverseGeocode.js
@@ -59,7 +59,7 @@ export default app => {
         .find({ paginate: false })
       app.info(`found ${entities.length} ${service} records`)
       entities.forEach(e => {
-        if ((!e.country && !e.state) || !e.postalcode || !e.street) {
+        if ((!e.country && !e.state) || !e.postalcode) {
           app.info(
             service,
             `adding ${service} record with id ${e.id} to geocoder queue`

--- a/map/package.json
+++ b/map/package.json
@@ -36,7 +36,7 @@
     "joi-browser": "13.4.0",
     "leaflet": "1.3.4",
     "leaflet.markercluster": "1.3.0",
-    "lodash": "4.17.10",
+    "lodash": "4.17.11",
     "node-polyglot": "2.3.0",
     "node-sass": "4.9.3",
     "normalize-css": "2.3.1",

--- a/map/src/containers/Details/components/Header.js
+++ b/map/src/containers/Details/components/Header.js
@@ -57,7 +57,7 @@ const FoundedAt = ({properties: {foundedAtYear = '', foundedAtMonth = ''}}) => {
 
 const Header = ({ feature }) => {
   const {
-    properties: { name, foundedAtYear, city, url }
+    properties: { name, foundedAtYear, postalcode, city, url }
   } = feature
   return (
     <header className="details-header">
@@ -66,7 +66,7 @@ const Header = ({ feature }) => {
       {foundedAtYear && FoundedAt(feature)}
 
       <div className="details-meta">
-        <p>{city}</p>
+        <p>{postalcode} {city}</p>
         {url && ExternalLink(url)}
       </div>
     </header>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8405,6 +8405,11 @@ lodash@4.17.10, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.1.0, lodash@^4.13.1,
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
+lodash@4.17.11:
+  version "4.17.11"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+
 logging-helpers@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/logging-helpers/-/logging-helpers-0.4.0.tgz#00e6d5316c23767ec12e1200e4f12c5e033e7eb0"


### PR DESCRIPTION
https://tree.taiga.io/project/sjockers-teikeinext/us/153

Reverse geocodes all entries to include the postalcode and also cleans up the city field (to remove any postcodes it may contain). 

Also adds and reverse geocodes street and housenumber (while keeping the address field), so we have a complete, clean address record.

This does not add country, postalcode, street or housenumber when geocoding new entries yet. Will be added when fixing/refactoring the geocoder frontend.