### PR TITLE
Bugfix: Entries still showing after deactivation

### DIFF
--- a/api/db/migrations/20190227201850_remove_inactive_entries_from_search.js
+++ b/api/db/migrations/20190227201850_remove_inactive_entries_from_search.js
@@ -1,0 +1,30 @@
+exports.up = function(knex, Promise) {
+  return Promise.all([
+    knex.raw(`
+    drop materialized view entries_search;
+    `),
+    knex.raw(`
+    create materialized view entries_search as
+    select id, 'farm' as type, name, to_tsvector(name) as search 
+    from farms 
+    where farms.active = true 
+    union 
+    select id, 'initiative' as type, name, to_tsvector(name) as search 
+    from initiatives
+    where initiatives.active = true 
+    union 
+    select id, 'depot' as type, name, to_tsvector(name) 
+    from depots
+    where depots.active = true ;
+    `),
+    knex.raw(`
+    create index idx_search on entries_search using GIN(search);`),
+    knex.raw(`
+    create unique index entries_search_id_type on entries_search(id, type)
+    `)
+  ])
+}
+
+exports.down = function(knex, Promise) {
+  return Promise.all([knex.raw('drop materialized view entries_search')])
+}

--- a/api/src/hooks/refreshSearchIndex.js
+++ b/api/src/hooks/refreshSearchIndex.js
@@ -1,0 +1,7 @@
+const refreshSearchIndex = ctx => {
+  ctx.app.service('searchindex').create({})
+  // return early, refresh in background
+  return ctx
+}
+
+export default refreshSearchIndex

--- a/api/src/queues/refreshSearchIndex.js
+++ b/api/src/queues/refreshSearchIndex.js
@@ -1,7 +1,5 @@
 import Queue from 'bull'
 
-import BaseModel from '../models/base'
-
 export const REFRESH_SEARCH_INDEX_QUEUE = {
   queueName: 'refresh_search_index',
   jobName: 'Refresh Search Index'
@@ -14,7 +12,7 @@ export default app => {
 
   queue.process(async job => {
     app.info('refreshing search index')
-    await BaseModel.raw('REFRESH MATERIALIZED VIEW CONCURRENTLY entries_search')
+    await app.service('searchindex').create({})
     job.progress(100)
   })
 

--- a/api/src/services/admin/depots.js
+++ b/api/src/services/admin/depots.js
@@ -4,6 +4,7 @@ import { DepotAdmin } from '../../models/depots'
 import addFilteredTotal from '../../hooks/admin'
 import { setCreatedAt, setUpdatedAt } from '../../hooks/audit'
 import { relate, withEager } from '../../hooks/relations'
+import refreshSearchIndex from '../../hooks/refreshSearchIndex'
 
 export default app => {
   const eager = '[ownerships, farms]'
@@ -28,7 +29,7 @@ export default app => {
       remove: []
     },
     after: {
-      all: [],
+      all: [refreshSearchIndex],
       find: [addFilteredTotal],
       get: [],
       create: [relate(DepotAdmin, 'ownerships'), relate(DepotAdmin, 'farms')],

--- a/api/src/services/admin/farms.js
+++ b/api/src/services/admin/farms.js
@@ -4,6 +4,7 @@ import { FarmAdmin } from '../../models/farms'
 import addFilteredTotal from '../../hooks/admin'
 import { setCreatedAt, setUpdatedAt } from '../../hooks/audit'
 import { relate, withEager } from '../../hooks/relations'
+import refreshSearchIndex from '../../hooks/refreshSearchIndex'
 
 export default app => {
   const eager = '[products, ownerships, depots]'
@@ -28,7 +29,7 @@ export default app => {
       remove: []
     },
     after: {
-      all: [],
+      all: [refreshSearchIndex],
       find: [addFilteredTotal],
       get: [],
       create: [

--- a/api/src/services/admin/initiatives.js
+++ b/api/src/services/admin/initiatives.js
@@ -4,6 +4,7 @@ import { InitiativeAdmin } from '../../models/initiatives'
 import { relate, withEager } from '../../hooks/relations'
 import addFilteredTotal from '../../hooks/admin'
 import { setCreatedAt, setUpdatedAt } from '../../hooks/audit'
+import refreshSearchIndex from '../../hooks/refreshSearchIndex'
 
 export default app => {
   const eager = '[goals, ownerships]'
@@ -19,7 +20,7 @@ export default app => {
   app.use('/admin/initiatives', service)
   app.service('/admin/initiatives').hooks({
     before: {
-      all: [],
+      all: [refreshSearchIndex],
       find: [withEager(eager)],
       get: [withEager(eager)],
       create: [setCreatedAt],

--- a/api/src/services/depots.js
+++ b/api/src/services/depots.js
@@ -14,6 +14,7 @@ import toGeoJSON from '../hooks/geoJson'
 import { setCreatedAt, setUpdatedAt } from '../hooks/audit'
 import { sendNewEntryNotification } from '../hooks/email'
 import filterAllowedFields from '../hooks/filterAllowedFields'
+import refreshSearchIndex from '../hooks/refreshSearchIndex'
 
 export default app => {
   const service = createService({
@@ -80,7 +81,7 @@ export default app => {
     })
     .hooks({
       after: {
-        all: [filterAllowedFields, toGeoJSON('farms')]
+        all: [filterAllowedFields, refreshSearchIndex, toGeoJSON('farms')]
       }
     })
 }

--- a/api/src/services/entries.js
+++ b/api/src/services/entries.js
@@ -10,7 +10,7 @@ import filterAllowedFields from '../hooks/filterAllowedFields'
 
 export default app => {
   const service = {
-    async find(params) {
+    find: async params => {
       const farms = await Farm.query()
         .eager(params.query.$eager || 'products')
         .modifyEager('products', b =>

--- a/api/src/services/entries.js
+++ b/api/src/services/entries.js
@@ -12,15 +12,18 @@ export default app => {
   const service = {
     find: async params => {
       const farms = await Farm.query()
+        .where({ active: true })
         .eager(params.query.$eager || 'products')
         .modifyEager('products', b =>
           b.select(['products.id', 'category', 'name'])
         )
         .select(entryColumns())
       const depots = await Depot.query()
+        .where({ active: true })
         .eager(params.query.$eager)
         .select(entryColumns())
       const initiatives = await Initiative.query()
+        .where({ active: true })
         .eager(params.query.$eager || 'goals')
         .select(entryColumns())
       return farms.concat(depots).concat(initiatives)

--- a/api/src/services/farms.js
+++ b/api/src/services/farms.js
@@ -14,6 +14,7 @@ import {
 import { setCreatedAt, setUpdatedAt } from '../hooks/audit'
 import { sendNewEntryNotification } from '../hooks/email'
 import filterAllowedFields from '../hooks/filterAllowedFields'
+import refreshSearchIndex from '../hooks/refreshSearchIndex'
 
 export default app => {
   const service = createService({
@@ -89,5 +90,9 @@ export default app => {
         remove: []
       }
     })
-    .hooks({ after: { all: [filterAllowedFields, toGeoJSON('depots')] } })
+    .hooks({
+      after: {
+        all: [filterAllowedFields, refreshSearchIndex, toGeoJSON('depots')]
+      }
+    })
 }

--- a/api/src/services/index.js
+++ b/api/src/services/index.js
@@ -1,18 +1,23 @@
 import authentication from './authentication'
 import authManagement from './authManagement'
-import autocomplete from './autocomplete'
-import depots from './depots'
+
 import emails from './emails'
 import emailPreview from './emailPreview'
-import entries from './entries'
 import entryContactMessage from './entryContactMessage'
+
+import entries from './entries'
+import depots from './depots'
 import farms from './farms'
-import geocoder from './geocoder'
-import reverseGeocoder from './reverseGeocoder'
 import initiatives from './initiatives'
+
 import users from './users'
 import products from './products'
 import goals from './goals'
+
+import geocoder from './geocoder'
+import reverseGeocoder from './reverseGeocoder'
+import autocomplete from './autocomplete'
+import searchIndex from './searchIndex'
 
 import adminFarms from './admin/farms'
 import adminDepots from './admin/depots'
@@ -37,6 +42,7 @@ export default app => {
   app.configure(users)
   app.configure(products)
   app.configure(goals)
+  app.configure(searchIndex)
   if (app.isDevelopment()) {
     app.configure(emailPreview)
   }

--- a/api/src/services/initiatives.js
+++ b/api/src/services/initiatives.js
@@ -13,6 +13,7 @@ import {
 } from '../hooks/relations'
 import { sendNewEntryNotification } from '../hooks/email'
 import filterAllowedFields from '../hooks/filterAllowedFields'
+import refreshSearchIndex from '../hooks/refreshSearchIndex'
 
 export default app => {
   const service = createService({
@@ -77,7 +78,7 @@ export default app => {
     })
     .hooks({
       after: {
-        all: [filterAllowedFields, toGeoJSON()]
+        all: [filterAllowedFields, refreshSearchIndex, toGeoJSON()]
       }
     })
 }

--- a/api/src/services/searchIndex.js
+++ b/api/src/services/searchIndex.js
@@ -1,0 +1,32 @@
+import BaseModel from '../models/base'
+
+export default app => {
+  const service = {
+    create: async () =>
+      BaseModel.raw('REFRESH MATERIALIZED VIEW CONCURRENTLY entries_search')
+  }
+
+  app.use('/searchindex', service)
+
+  app
+    .service('searchindex')
+    .hooks({
+      before: {
+        all: [],
+        find: []
+      },
+      after: {
+        all: [],
+        find: []
+      },
+      error: {
+        all: [],
+        find: []
+      }
+    })
+    .hooks({
+      after: {
+        all: []
+      }
+    })
+}


### PR DESCRIPTION
fixes 
https://tree.taiga.io/project/sjockers-teikeinext/issue/158
https://tree.taiga.io/project/sjockers-teikeinext/us/160

- Deactivated entries no longer show up in combined entry endpoint (/entries)
- Deactivated entries are removed from the search index
- The search index is now refreshed in the background after every user action instead of every 5 minutes. Need to see how this performs, but seems doable with our current load.