### PR TITLE
bugfix: increase SVG stroke-miterlimit

### DIFF
--- a/packages/map/public/assets/marker-depot.svg
+++ b/packages/map/public/assets/marker-depot.svg
@@ -10,12 +10,12 @@
 		c0,6.2,0,12.4-2.1,18.5c0,2.1-4.1,4.1-6.2,4.1h-76.2c-4.1,0-6.2-2.1-6.2-4.1c-2.1-6.2-2.1-12.4-2.1-18.5c0-6.2,0-12.4,2.1-18.5
 		c0-2.1,4.1-4.1,6.2-4.1h76.2C662.8,1290.6,666.9,1292.7,666.9,1294.8z"/>
 </g>
-<path opacity="0.65" fill="#FFFFFF" stroke="#B5B5B5" stroke-width="5" stroke-miterlimit="10" d="M424.6,73.1
+<path opacity="0.65" fill="#FFFFFF" stroke="#B5B5B5" stroke-width="5" stroke-miterlimit="50" d="M424.6,73.1
 	c-96.8-96.8-251.2-94.7-348,0s-96.8,251.2,0,348l173,173l175-175C519.3,324.3,519.3,169.8,424.6,73.1z"/>
 <g opacity="0.6">
-	<circle fill="#FFFFFF" stroke="#CCCCCC" stroke-width="5" stroke-miterlimit="10" cx="249.6" cy="245.8" r="195.7"/>
-	<circle fill="#FFFFFF" stroke="#CCCCCC" stroke-width="5" stroke-miterlimit="10" cx="249.6" cy="245.8" r="195.7"/>
-	<circle opacity="0" fill="#FFFFFF" stroke="#CCCCCC" stroke-width="5" stroke-miterlimit="10" cx="249.6" cy="245.8" r="185.1"/>
+	<circle fill="#FFFFFF" stroke="#CCCCCC" stroke-width="5" stroke-miterlimit="50" cx="249.6" cy="245.8" r="195.7"/>
+	<circle fill="#FFFFFF" stroke="#CCCCCC" stroke-width="5" stroke-miterlimit="50" cx="249.6" cy="245.8" r="195.7"/>
+	<circle opacity="0" fill="#FFFFFF" stroke="#CCCCCC" stroke-width="5" stroke-miterlimit="50" cx="249.6" cy="245.8" r="185.1"/>
 </g>
 <g enable-background="new    ">
 	<path fill="#235F87" d="M304,142.2c3.4-2.9,8.5-2.5,11.2,0.9l10.8,12.6c2.9,3.4,2.5,8.5-0.9,11.5l-47.2,39.5l68.1,0

--- a/packages/map/public/assets/marker-farm.svg
+++ b/packages/map/public/assets/marker-farm.svg
@@ -2,12 +2,12 @@
 <!-- Generator: Adobe Illustrator 18.1.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 497.8 595.3" enable-background="new 0 0 497.8 595.3" xml:space="preserve">
-<path opacity="0.65" fill="#FFFFFF" stroke="#B5B5B5" stroke-width="5" stroke-miterlimit="10" d="M424.7,74.3
+<path opacity="0.65" fill="#FFFFFF" stroke="#B5B5B5" stroke-width="5" stroke-miterlimit="50" d="M424.7,74.3
 	c-96.8-96.8-251.2-94.7-348,0s-96.8,251.2,0,348l173,173l175-175C519.4,325.5,519.4,171.1,424.7,74.3z"/>
 <g opacity="0.6">
-	<circle fill="#FFFFFF" stroke="#CCCCCC" stroke-width="5" stroke-miterlimit="10" cx="249.6" cy="247" r="195.7"/>
-	<circle fill="#FFFFFF" stroke="#CCCCCC" stroke-width="5" stroke-miterlimit="10" cx="249.6" cy="247" r="195.7"/>
-	<circle opacity="0" fill="#FFFFFF" stroke="#CCCCCC" stroke-width="5" stroke-miterlimit="10" cx="249.6" cy="247" r="185.1"/>
+	<circle fill="#FFFFFF" stroke="#CCCCCC" stroke-width="5" stroke-miterlimit="50" cx="249.6" cy="247" r="195.7"/>
+	<circle fill="#FFFFFF" stroke="#CCCCCC" stroke-width="5" stroke-miterlimit="50" cx="249.6" cy="247" r="195.7"/>
+	<circle opacity="0" fill="#FFFFFF" stroke="#CCCCCC" stroke-width="5" stroke-miterlimit="50" cx="249.6" cy="247" r="185.1"/>
 </g>
 <g display="none">
 	<path display="inline" fill="#DC6425" d="M570.1,1358.6c-26.8,0-47.4-20.6-47.4-47.4c0-26.8,20.6-47.4,47.4-47.4

--- a/packages/map/public/assets/marker-initiative.svg
+++ b/packages/map/public/assets/marker-initiative.svg
@@ -5,9 +5,9 @@
 <style type="text/css">
 	.st0{display:none;}
 	.st1{display:inline;fill:#3E6889;}
-	.st2{opacity:0.65;fill:#FFFFFF;stroke:#B5B5B5;stroke-width:5;stroke-miterlimit:10;enable-background:new    ;}
+	.st2{opacity:0.65;fill:#FFFFFF;stroke:#B5B5B5;stroke-width:5;stroke-miterlimit:50;enable-background:new    ;}
 	.st3{opacity:0.6;}
-	.st4{fill:#FFFFFF;stroke:#CCCCCC;stroke-width:5;stroke-miterlimit:10;}
+	.st4{fill:#FFFFFF;stroke:#CCCCCC;stroke-width:5;stroke-miterlimit:50;}
 	.st5{fill:#FFFFFF;fill-opacity:0;}
 	.st6{fill:#B22D69;}
 </style>


### PR DESCRIPTION
 Increase stroke-miterlimit to correctly display SVG markers in Safari. 