### PR TITLE
Fix layout issues with user navigation (mobile)

### DIFF
--- a/packages/admin/src/index.css
+++ b/packages/admin/src/index.css
@@ -1,13 +1,13 @@
 body {
   margin: 0;
-  font-family:
-    -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
-    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+    'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
+    'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family:
-    source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+    monospace;
 }

--- a/packages/map/src/components/page/EntriesNavigation.tsx
+++ b/packages/map/src/components/page/EntriesNavigation.tsx
@@ -36,7 +36,7 @@ const EntriesNavigation = () => {
   return (
     <Dropdown
       className='entries-nav'
-      label={t('nav.edit_entries')}
+      label={t('nav.entries')}
       labelClassName='entries-nav-toggle'
       menuComponent={<EntriesNavigationDropdown />}
     />

--- a/packages/map/src/components/page/Navigation.tsx
+++ b/packages/map/src/components/page/Navigation.tsx
@@ -35,13 +35,13 @@ const LoggedInNavigation = ({
   <div className='user-nav'>
     <ul>
       <li>
-        <EntriesNavigation />
-      </li>
-      <li>
         <AccountNavigation
           username={username}
           onSignOutClick={onSignOutClick}
         />
+      </li>
+      <li>
+        <EntriesNavigation />
       </li>
       {config.externalHelpUrl && (
         <li>

--- a/packages/map/src/locales/de-CH/common.json
+++ b/packages/map/src/locales/de-CH/common.json
@@ -137,6 +137,7 @@
   "nav.edit_account": "Benutzerdaten anpassen",
   "nav.edit_entries": "Einträge hinzufügen / bearbeiten",
   "nav.edit_password": "Passwort ändern",
+  "nav.entries": "Einträge",
   "nav.go_back": "Zurück zur Übersichtskarte",
   "nav.help": "Information",
   "nav.logout": "Abmelden",

--- a/packages/map/src/locales/de-DE/common.json
+++ b/packages/map/src/locales/de-DE/common.json
@@ -137,6 +137,7 @@
   "nav.edit_account": "Benutzerdaten anpassen",
   "nav.edit_entries": "Einträge hinzufügen / bearbeiten",
   "nav.edit_password": "Passwort ändern",
+  "nav.entries": "Einträge",
   "nav.go_back": "Zurück zur Übersichtskarte",
   "nav.help": "Information",
   "nav.logout": "Abmelden",

--- a/packages/map/src/locales/fr-CH/common.json
+++ b/packages/map/src/locales/fr-CH/common.json
@@ -137,6 +137,7 @@
   "nav.edit_account": "Modifier les données utilisateur",
   "nav.edit_entries": "Ajouter / Modifier des entrées",
   "nav.edit_password": "Changer le mot de passe",
+  "nav.entries": "Entrées",
   "nav.go_back": "Retour à la carte",
   "nav.help": "Information",
   "nav.logout": "Se déconnecter",

--- a/packages/map/src/styles/common/_dropdown.scss
+++ b/packages/map/src/styles/common/_dropdown.scss
@@ -1,20 +1,12 @@
 .dropdown {
-  position: absolute;
-  top: 0;
-  right: 0;
+  position: relative;
 }
 
 .dropdown-menu {
   z-index: 1000;
   box-shadow: 2px 2px 30px rgba(black, 0.3);
   display: block;
-
-  @media (min-width: $mobile) {
-    position: fixed;
-    top: 75px;
-    right: 0;
-    left: 0;
-  }
+  position: fixed;
 
   @media (min-width: $tablet) {
     position: absolute;
@@ -48,10 +40,6 @@
     bottom: 0;
     width: 100%;
     background: rgba(black, 0.5);
-
-    @media (min-width: $mobile) {
-      display: block;
-    }
   }
 
   ul {

--- a/packages/map/src/styles/components/_account-nav.scss
+++ b/packages/map/src/styles/components/_account-nav.scss
@@ -2,7 +2,7 @@
   pointer-events: auto;
   display: inline-block;
   margin-right: 1rem;
-  
+
   @media (min-width: $tablet) {
     position: absolute;
     right: 170px;
@@ -72,16 +72,17 @@
   top: 70px;
 
   > ul {
-      @include wrapper;
-      height: 100px;
-      position: relative;
-      height: 100%;
-      list-style: none;
-      top: 0;
-      display: flex;
+    @include wrapper;
+    height: 100px;
+    position: relative;
+    height: 100%;
+    list-style: none;
+    top: 0;
+    display: flex;
   }
 
-  a, button {
+  a,
+  button {
     pointer-events: auto;
     cursor: pointer;
   }
@@ -95,5 +96,4 @@
     width: 100%;
     pointer-events: none;
   }
-
 }

--- a/packages/map/src/styles/components/_account-nav.scss
+++ b/packages/map/src/styles/components/_account-nav.scss
@@ -1,10 +1,10 @@
 .account-nav {
-  position: absolute;
-  right: 0;
-  top: 0;
   pointer-events: auto;
-
+  display: inline-block;
+  margin-right: 1rem;
+  
   @media (min-width: $tablet) {
+    position: absolute;
     right: 170px;
     top: 30px;
   }
@@ -23,24 +23,13 @@
   text-decoration: none;
   background-color: rgba(darken($charcoal, 5), 0.55);
   overflow: hidden;
+  cursor: pointer;
 
   &:hover,
   &:focus {
     text-decoration: none;
     background: rgba(darken($charcoal, 5), 0.9);
     color: $white;
-  }
-
-  @media (min-width: $mobile) {
-    position: absolute;
-    top: 20px;
-    right: 60px;
-    width: 35px;
-    height: 35px;
-    padding: 0 10px;
-    font-size: 18px;
-    line-height: 30px;
-    border-radius: 50%;
   }
 
   @media (min-width: $tablet) {
@@ -80,25 +69,31 @@
 
 .user-nav {
   position: fixed;
-  top: 0;
-  right: 0;
-  z-index: 10;
-  width: 100%;
-  pointer-events: none;
-  bottom: 0;
+  top: 70px;
 
-  @media (min-width: $tablet) {
-    > ul {
+  > ul {
       @include wrapper;
       height: 100px;
       position: relative;
       height: 100%;
       list-style: none;
-      margin-top: 0;
-    }
-
-    a {
-      pointer-events: auto;
-    }
+      top: 0;
+      display: flex;
   }
+
+  a, button {
+    pointer-events: auto;
+    cursor: pointer;
+  }
+
+  @media (min-width: $tablet) {
+    display: block;
+    position: fixed;
+    top: 0;
+    right: 0;
+    z-index: 10;
+    width: 100%;
+    pointer-events: none;
+  }
+
 }

--- a/packages/map/src/styles/components/_entries-nav.scss
+++ b/packages/map/src/styles/components/_entries-nav.scss
@@ -4,7 +4,7 @@
 .entries-nav {
   pointer-events: auto;
   display: inline-block;
-    
+
   @media (min-width: $tablet) {
     position: absolute;
     z-index: 10;

--- a/packages/map/src/styles/components/_entries-nav.scss
+++ b/packages/map/src/styles/components/_entries-nav.scss
@@ -2,13 +2,12 @@
 // Figure out how to handle this on mobile
 
 .entries-nav {
-  position: absolute;
-  right: 0;
-  top: 0;
-  z-index: 10;
   pointer-events: auto;
-
+  display: inline-block;
+    
   @media (min-width: $tablet) {
+    position: absolute;
+    z-index: 10;
     top: 120px;
     right: 20px;
   }
@@ -41,6 +40,7 @@
 .entries-nav-toggle {
   display: block;
   border: 0;
+  padding: 5px;
   outline: none;
   overflow: hidden;
   white-space: nowrap;
@@ -50,18 +50,6 @@
   color: $white;
   font-weight: bold;
   transition: background-color 0.2s;
-
-  @media (min-width: $mobile) {
-    position: absolute;
-    top: 20px;
-    right: 100px;
-    width: 35px;
-    height: 35px;
-    padding: 0 10px;
-    font-size: 18px;
-    line-height: 30px;
-    border-radius: 50%;
-  }
 
   @media (min-width: $tablet) {
     width: auto;

--- a/packages/map/src/webtests/depots.spec.ts
+++ b/packages/map/src/webtests/depots.spec.ts
@@ -6,7 +6,7 @@ test.describe('Depots', () => {
     await goToPageAndLoginAsUser(page)
     // create a depot
     await page
-      .getByRole('button', { name: 'Einträge hinzufügen / bearbeiten' })
+      .getByRole('button', { name: 'Einträge' })
       .click()
     await page.getByRole('link', { name: 'Abholstellen hinzufügen' }).click()
     await page.locator('input[name="name"]').fill('Webtest Depot 1')
@@ -52,7 +52,7 @@ test.describe('Depots', () => {
     // edit the depot
     await page.getByRole('link', { name: 'Zurück zur Übersichtskarte' }).click()
     await page
-      .getByRole('button', { name: 'Einträge hinzufügen / bearbeiten' })
+      .getByRole('button', { name: 'Einträge' })
       .click()
     await page.getByRole('link', { name: 'Meine Einträge' }).click()
     await page.getByRole('link', { name: 'Bearbeiten' }).click()
@@ -98,7 +98,7 @@ test.describe('Depots', () => {
     // delete the depot
     await page.getByRole('link', { name: 'Zurück zur Übersichtskarte' }).click()
     await page
-      .getByRole('button', { name: 'Einträge hinzufügen / bearbeiten' })
+      .getByRole('button', { name: 'Einträge' })
       .click()
     await page.getByRole('link', { name: 'Meine Einträge' }).click()
     await page.getByRole('link', { name: 'Löschen' }).click()

--- a/packages/map/src/webtests/depots.spec.ts
+++ b/packages/map/src/webtests/depots.spec.ts
@@ -5,9 +5,7 @@ test.describe('Depots', () => {
   test('user can manage depots', async ({ page }) => {
     await goToPageAndLoginAsUser(page)
     // create a depot
-    await page
-      .getByRole('button', { name: 'Einträge' })
-      .click()
+    await page.getByRole('button', { name: 'Einträge' }).click()
     await page.getByRole('link', { name: 'Abholstellen hinzufügen' }).click()
     await page.locator('input[name="name"]').fill('Webtest Depot 1')
     await page
@@ -51,9 +49,7 @@ test.describe('Depots', () => {
 
     // edit the depot
     await page.getByRole('link', { name: 'Zurück zur Übersichtskarte' }).click()
-    await page
-      .getByRole('button', { name: 'Einträge' })
-      .click()
+    await page.getByRole('button', { name: 'Einträge' }).click()
     await page.getByRole('link', { name: 'Meine Einträge' }).click()
     await page.getByRole('link', { name: 'Bearbeiten' }).click()
     await page.locator('input[name="name"]').fill('Webtest Depot 2')
@@ -97,9 +93,7 @@ test.describe('Depots', () => {
 
     // delete the depot
     await page.getByRole('link', { name: 'Zurück zur Übersichtskarte' }).click()
-    await page
-      .getByRole('button', { name: 'Einträge' })
-      .click()
+    await page.getByRole('button', { name: 'Einträge' }).click()
     await page.getByRole('link', { name: 'Meine Einträge' }).click()
     await page.getByRole('link', { name: 'Löschen' }).click()
     await page.getByRole('button', { name: 'Löschen' }).click()

--- a/packages/map/src/webtests/farms.spec.ts
+++ b/packages/map/src/webtests/farms.spec.ts
@@ -5,9 +5,7 @@ test.describe('Farms', () => {
   test('user can manage farms', async ({ page }) => {
     await goToPageAndLoginAsUser(page)
     // create a farm
-    await page
-      .getByRole('button', { name: 'Einträge' })
-      .click()
+    await page.getByRole('button', { name: 'Einträge' }).click()
     await page.getByRole('link', { name: 'Betrieb hinzufügen' }).click()
     await page.locator('input[name="name"]').click()
     await page.locator('input[name="name"]').fill('Webtest Farm 1')
@@ -100,9 +98,7 @@ test.describe('Farms', () => {
     ).toBeVisible()
 
     // edit the farm
-    await page
-      .getByRole('button', { name: 'Einträge' })
-      .click()
+    await page.getByRole('button', { name: 'Einträge' }).click()
     await page.getByRole('link', { name: 'Meine Einträge' }).click()
     await page.getByRole('link', { name: 'Bearbeiten' }).first().click()
     await page.locator('input[name="name"]').click()
@@ -192,9 +188,7 @@ test.describe('Farms', () => {
     ).toBeVisible()
 
     // delete the farm
-    await page
-      .getByRole('button', { name: 'Einträge' })
-      .click()
+    await page.getByRole('button', { name: 'Einträge' }).click()
     await page.getByRole('link', { name: 'Meine Einträge' }).click()
     await page.getByRole('link', { name: 'Löschen' }).first().click()
     await page.getByRole('button', { name: 'Löschen' }).click()

--- a/packages/map/src/webtests/farms.spec.ts
+++ b/packages/map/src/webtests/farms.spec.ts
@@ -6,7 +6,7 @@ test.describe('Farms', () => {
     await goToPageAndLoginAsUser(page)
     // create a farm
     await page
-      .getByRole('button', { name: 'Einträge hinzufügen / bearbeiten' })
+      .getByRole('button', { name: 'Einträge' })
       .click()
     await page.getByRole('link', { name: 'Betrieb hinzufügen' }).click()
     await page.locator('input[name="name"]').click()
@@ -101,7 +101,7 @@ test.describe('Farms', () => {
 
     // edit the farm
     await page
-      .getByRole('button', { name: 'Einträge hinzufügen / bearbeiten' })
+      .getByRole('button', { name: 'Einträge' })
       .click()
     await page.getByRole('link', { name: 'Meine Einträge' }).click()
     await page.getByRole('link', { name: 'Bearbeiten' }).first().click()
@@ -193,7 +193,7 @@ test.describe('Farms', () => {
 
     // delete the farm
     await page
-      .getByRole('button', { name: 'Einträge hinzufügen / bearbeiten' })
+      .getByRole('button', { name: 'Einträge' })
       .click()
     await page.getByRole('link', { name: 'Meine Einträge' }).click()
     await page.getByRole('link', { name: 'Löschen' }).first().click()

--- a/packages/map/src/webtests/initiatives.spec.ts
+++ b/packages/map/src/webtests/initiatives.spec.ts
@@ -5,9 +5,7 @@ test.describe('Initiatives', () => {
   test('user can manage initiatives', async ({ page }) => {
     await goToPageAndLoginAsUser(page)
     // create an initiative
-    await page
-      .getByRole('button', { name: 'Einträge' })
-      .click()
+    await page.getByRole('button', { name: 'Einträge' }).click()
     await page.getByRole('link', { name: 'Initiative hinzufügen' }).click()
     await page.getByText('Wir suchen Land oder Hof').click()
     await page
@@ -52,9 +50,7 @@ test.describe('Initiatives', () => {
 
     // edit the initiative
     await page.getByRole('link', { name: 'Zurück zur Übersichtskarte' }).click()
-    await page
-      .getByRole('button', { name: 'Einträge' })
-      .click()
+    await page.getByRole('button', { name: 'Einträge' }).click()
     await page.getByRole('link', { name: 'Meine Einträge' }).click()
     await page.getByRole('link', { name: 'Bearbeiten' }).click()
     await page.getByLabel('Wir suchen GärtnerInnen oder LandwirtInnen').check()
@@ -96,9 +92,7 @@ test.describe('Initiatives', () => {
     ).toBeVisible()
     await expect(page.getByText('Wir suchen KonsumentInnen')).toBeVisible()
 
-    await page
-      .getByRole('button', { name: 'Einträge' })
-      .click()
+    await page.getByRole('button', { name: 'Einträge' }).click()
     await page.getByRole('link', { name: 'Meine Einträge' }).click()
     await page.getByRole('link', { name: 'Löschen' }).click()
     await page.getByRole('button', { name: 'Löschen' }).click()

--- a/packages/map/src/webtests/initiatives.spec.ts
+++ b/packages/map/src/webtests/initiatives.spec.ts
@@ -6,7 +6,7 @@ test.describe('Initiatives', () => {
     await goToPageAndLoginAsUser(page)
     // create an initiative
     await page
-      .getByRole('button', { name: 'Einträge hinzufügen / bearbeiten' })
+      .getByRole('button', { name: 'Einträge' })
       .click()
     await page.getByRole('link', { name: 'Initiative hinzufügen' }).click()
     await page.getByText('Wir suchen Land oder Hof').click()
@@ -53,7 +53,7 @@ test.describe('Initiatives', () => {
     // edit the initiative
     await page.getByRole('link', { name: 'Zurück zur Übersichtskarte' }).click()
     await page
-      .getByRole('button', { name: 'Einträge hinzufügen / bearbeiten' })
+      .getByRole('button', { name: 'Einträge' })
       .click()
     await page.getByRole('link', { name: 'Meine Einträge' }).click()
     await page.getByRole('link', { name: 'Bearbeiten' }).click()
@@ -97,7 +97,7 @@ test.describe('Initiatives', () => {
     await expect(page.getByText('Wir suchen KonsumentInnen')).toBeVisible()
 
     await page
-      .getByRole('button', { name: 'Einträge hinzufügen / bearbeiten' })
+      .getByRole('button', { name: 'Einträge' })
       .click()
     await page.getByRole('link', { name: 'Meine Einträge' }).click()
     await page.getByRole('link', { name: 'Löschen' }).click()


### PR DESCRIPTION
- Implement simpler layout for user navigation (mobile / logged-in users)
- Use shorter title for 'Entries' dropdown toggle (works better on small screens)
- Remove unused mobile styles

<img width="498" height="627" alt="image" src="https://github.com/user-attachments/assets/55542f8b-f12c-41db-8ab7-8d1a1fc79e9b" />
