### PR TITLE
cleanup react-admin layouts.

### DIFF
--- a/packages/admin/src/App.jsx
+++ b/packages/admin/src/App.jsx
@@ -1,7 +1,7 @@
 import { jwtDecode } from 'jwt-decode'
 import { restClient } from 'ra-data-feathers'
 import { useEffect, useState } from 'react'
-import { Admin, Resource, Title } from 'react-admin'
+import { Admin, Resource } from 'react-admin'
 import { hasAdminRole, hasSuperAdminRole } from './authorization'
 import Dashboard from './components/Dashboard'
 import Layout from './components/Layout'
@@ -78,10 +78,10 @@ const App = () => {
       theme={theme}
       dashboard={Dashboard}
       layout={Layout}
+      title='Ernte Teilen'
     >
       {(roles) => {
         return [
-          <Title key='title' title='Ernte Teilen - ' />,
           hasAdminRole(roles) && (
             <Resource
               key='admin/entries'

--- a/packages/admin/src/components/AppBar.jsx
+++ b/packages/admin/src/components/AppBar.jsx
@@ -1,7 +1,6 @@
 import { Box } from '@mui/material'
-import Typography from '@mui/material/Typography'
 import { makeStyles } from '@mui/styles'
-import { AppBar as RaAppBar } from 'react-admin'
+import { AppBar as RaAppBar, TitlePortal } from 'react-admin'
 
 const useStyles = makeStyles({
   navLink: {
@@ -20,7 +19,7 @@ const AppBar = (props) => {
   return (
     <RaAppBar {...props} className={classes.appBar}>
       <Box flex='1'>
-        <Typography variant='h6' id='react-admin-title' />
+        <TitlePortal />
       </Box>
       {/* <a href="#/docs" className={classes.navLink}> */}
       {/*  API Docs */}

--- a/packages/admin/src/components/AppMenu.jsx
+++ b/packages/admin/src/components/AppMenu.jsx
@@ -1,149 +1,94 @@
 import DefaultIcon from '@mui/icons-material/ViewList'
-import { makeStyles } from '@mui/styles'
-import classnames from 'classnames'
-import _ from 'lodash'
-import { DashboardMenuItem, MenuItemLink, usePermissions } from 'react-admin'
+import { Menu, usePermissions } from 'react-admin'
 import { hasAdminRole, hasSuperAdminRole } from '../authorization'
 
 export const MENU_WIDTH = 240
 export const CLOSED_MENU_WIDTH = 55
 
-const useStyles = makeStyles(
-  (theme) => ({
-    main: {
-      display: 'flex',
-      flexDirection: 'column',
-      justifyContent: 'flex-start',
-      marginTop: '0.5em',
-      [theme.breakpoints.only('xs')]: {
-        marginTop: 0
-      },
-      [theme.breakpoints.up('md')]: {
-        marginTop: '1.5em'
-      }
-    },
-    open: {
-      width: _.get(theme, 'menu.width', MENU_WIDTH)
-    },
-    closed: {
-      width: _.get(theme, 'menu.closedWidth', CLOSED_MENU_WIDTH)
-    }
-  }),
-  { name: 'RaMenu' }
-)
-
-const AppMenu = (props) => {
+const AppMenu = () => {
   const { permissions } = usePermissions()
 
-  const classes = useStyles(props)
-  const { onMenuClick, className } = props
   return (
-    <div
-      className={classnames(
-        classes.main,
-        {
-          [classes.open]: open,
-          [classes.closed]: !open
-        },
-        className
-      )}
-    >
+    <Menu>
       {hasAdminRole(permissions) && (
         <>
-          <DashboardMenuItem
-            to='/'
-            primaryText='Dashboard'
-            onClick={onMenuClick}
-          />
-          <MenuItemLink
+          <Menu.DashboardItem />
+          <Menu.Item
             to='/admin/farms'
             primaryText='Farms'
-            onClick={onMenuClick}
             leftIcon={<DefaultIcon />}
           />
-          <MenuItemLink
+          <Menu.Item
             to='/admin/depots'
             primaryText='Depots'
-            onClick={onMenuClick}
             leftIcon={<DefaultIcon />}
           />
-          <MenuItemLink
+          <Menu.Item
             to='/admin/initiatives'
             primaryText='Initiatives'
-            onClick={onMenuClick}
             leftIcon={<DefaultIcon />}
           />
-          <MenuItemLink
+          <Menu.Item
             to='/admin/users'
             primaryText='Users'
-            onClick={onMenuClick}
             leftIcon={<DefaultIcon />}
           />
-          <MenuItemLink
+          <Menu.Item
             to='/admin/bounces'
             primaryText='Bounces'
-            onClick={onMenuClick}
             leftIcon={<DefaultIcon />}
           />
         </>
       )}
       {hasSuperAdminRole(permissions) && (
         <>
-          <MenuItemLink
+          <Menu.Item
             to='/admin/badges'
             primaryText='Badges'
-            onClick={onMenuClick}
             leftIcon={<DefaultIcon />}
           />
-          <MenuItemLink
+          <Menu.Item
             to='/admin/goals'
             primaryText='Goals'
-            onClick={onMenuClick}
             leftIcon={<DefaultIcon />}
           />
-          <MenuItemLink
+          <Menu.Item
             to='/admin/products'
             primaryText='Products'
-            onClick={onMenuClick}
             leftIcon={<DefaultIcon />}
           />
-          <MenuItemLink
+          <Menu.Item
             to='/admin/roles'
             primaryText='Roles'
-            onClick={onMenuClick}
             leftIcon={<DefaultIcon />}
           />
-          <MenuItemLink
+          <Menu.Item
             to='/admin/origins'
             primaryText='Origins'
-            onClick={onMenuClick}
             leftIcon={<DefaultIcon />}
           />
-          <MenuItemLink
+          <Menu.Item
             to='/admin/jobs'
             primaryText='Jobs'
-            onClick={onMenuClick}
             leftIcon={<DefaultIcon />}
           />
         </>
       )}
       {hasSuperAdminRole(permissions) && (
         <>
-          <MenuItemLink
+          <Menu.Item
             to='/admin/email-campaigns'
             primaryText='Email Campaigns'
-            onClick={onMenuClick}
             leftIcon={<DefaultIcon />}
           />
-          <MenuItemLink
+          <Menu.Item
             to='/admin/email-messages'
             primaryText='Email Messages'
-            onClick={onMenuClick}
             leftIcon={<DefaultIcon />}
           />
         </>
       )}
-    </div>
+    </Menu>
   )
 }
 

--- a/packages/admin/src/theme.js
+++ b/packages/admin/src/theme.js
@@ -7,10 +7,12 @@ const theme = createTheme({
     },
     secondary: {
       main: '#266050'
-    },
-    overrides: {
-      '.RaLogin-main-77': {
-        background: 'red'
+    }
+  },
+  components: {
+    RaPasswordInput: {
+      defaultProps: {
+        size: 'medium'
       }
     }
   }


### PR DESCRIPTION
## Summary
- Switched the admin app shell to react-admin's built-in `title`/`TitlePortal` flow instead of the legacy title hack.
- Replaced the custom sidebar menu implementation with react-admin `Menu` and `Menu.Item` primitives.
- Cleaned up theme overrides and moved password input sizing into component defaults.

## Testing
- Not run
- Review the admin UI shell for the app bar title and menu rendering
- Verify admin and super-admin role-based menu visibility still matches the previous behavior