### PR TITLE
build: use npm ci in setup to stop recurring lockfile drift

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "webtests": "start-server-and-test _webtests:server http://localhost:3000 _webtests:run",
     "webtests:ui": "start-server-and-test _webtests:server http://localhost:3000 _webtests:run:ui",
     "clean": "lerna exec -- npm run clean",
-    "install": "lerna exec -- npm install --legacy-peer-deps",
+    "install": "lerna exec -- npm ci --legacy-peer-deps",
     "audit": "lerna exec -- npm audit --omit=dev",
     "prepare": "husky",
     "_db:up": "cd packages/api && npm run dev-db-startdocker",

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -26,9 +26,12 @@ else
 fi
 
 echo "==> Installing npm dependencies"
-# Root install cascades into every package via the `install` lifecycle script
-# ("lerna exec -- npm install --legacy-peer-deps"), so map-next is installed too.
-npm install
+# Use `npm ci` (not `npm install`) so setup installs strictly from the committed
+# lockfiles and never rewrites them. `npm install` re-solves per platform and, on
+# macOS, strips the Linux-only `libc` metadata that CI writes, causing recurring
+# lockfile drift. `npm ci` cascades into every package via the `install` lifecycle
+# script ("lerna exec -- npm ci --legacy-peer-deps"), so map-next is installed too.
+npm ci
 
 echo "==> Linking env secrets"
 "$SCRIPT_DIR/link-env.sh"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -26,11 +26,6 @@ else
 fi
 
 echo "==> Installing npm dependencies"
-# Use `npm ci` (not `npm install`) so setup installs strictly from the committed
-# lockfiles and never rewrites them. `npm install` re-solves per platform and, on
-# macOS, strips the Linux-only `libc` metadata that CI writes, causing recurring
-# lockfile drift. `npm ci` cascades into every package via the `install` lifecycle
-# script ("lerna exec -- npm ci --legacy-peer-deps"), so map-next is installed too.
 npm ci
 
 echo "==> Linking env secrets"


### PR DESCRIPTION
## Problem

Every fresh Conductor workspace (and any local `scripts/setup.sh` run) produced spurious `package-lock.json` diffs across **all five** packages — repeatedly surfacing in unrelated PRs and needing manual reverts.

## Root cause

`setup.sh` ran `npm install`, which re-solves the dependency tree for the **current platform** and rewrites the lockfiles. On macOS, npm strips the Linux-only `"libc": ["glibc"|"musl"]` metadata (on rollup/sharp native optional deps) that CI writes on Linux — plus some `dev`/`devOptional` graph churn. The root `install` lifecycle script cascades the same `npm install` into every package via `lerna exec`, so one setup touched every lockfile.

## Fix

Two coupled changes so nothing re-solves during setup:

1. **`scripts/setup.sh`**: `npm install` → `npm ci`
2. **`package.json`** root `install` lifecycle: `lerna exec -- npm install --legacy-peer-deps` → `lerna exec -- npm ci --legacy-peer-deps`

`npm ci` installs **strictly from the committed lockfile and never writes to it** (it errors on drift instead), and it's what CI already uses — so dev setup now matches CI exactly. Both edits are needed because `npm ci` still fires the `install` lifecycle; leaving that hook on `npm install` would re-introduce the per-package drift.

Adding dependencies is unaffected — that's still an explicit `cd packages/<pkg> && npm install <dep>`.

## Verification

Ran `npm ci --dry-run` (under the `.nvmrc` node 24.12.0 that setup selects) for the root and all four packages — every lockfile is in sync, so the switch won't start failing setup.

## Note

This branch is based on `preview`, which still contains the `EntryCard.svelte` lint error fixed separately in #848. Lint CI here will go green once #848 lands (rebase if needed). This PR itself only touches `setup.sh` and `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)