### PR TITLE
feat(map-next): map visual language — markers, clusters, popups (Feature 13)

### DIFF
--- a/packages/map-next/src/lib/components/domain/map/Popup.svelte
+++ b/packages/map-next/src/lib/components/domain/map/Popup.svelte
@@ -42,7 +42,7 @@
 >
 	<div class="entry-popup">
 		<div class="flex min-w-0 flex-col gap-0.5">
-			<span class="truncate text-background">{feature?.properties.name}</span>
+			<span class="truncate font-medium text-card-foreground">{feature?.properties.name}</span>
 			<span class="truncate text-muted-foreground">
 				{feature?.properties.city}
 			</span>
@@ -58,17 +58,21 @@
 		padding: 0rem 0.25rem;
 	}
 
-	:global(.map) {
-		--popup-bg-color: var(--map-popup);
-		--popup-opacity: 0.8;
-	}
-
+	/*
+	 * Restyle the MapLibre popup as a flat card (spec F13): card background/
+	 * foreground tokens, the app radius scale, and a restrained shadow —
+	 * replacing the previous 0.8-opacity dark box. Works in every theme.
+	 */
 	:global(.map .maplibregl-popup-content) {
-		background: var(--popup-bg-color);
-		opacity: var(--popup-opacity);
+		background: var(--card);
+		color: var(--card-foreground);
+		border-radius: var(--radius);
+		box-shadow: 0 4px 12px color-mix(in srgb, var(--foreground) 15%, transparent);
 	}
-	:global(.maplibregl-popup-anchor-bottom .maplibregl-popup-tip) {
-		border-top-color: var(--popup-bg-color);
-		opacity: var(--popup-opacity);
+	:global(.map .maplibregl-popup-anchor-bottom .maplibregl-popup-tip) {
+		border-top-color: var(--card);
+	}
+	:global(.map .maplibregl-popup-close-button) {
+		color: var(--muted-foreground);
 	}
 </style>

--- a/packages/map-next/src/lib/components/domain/map/SymbolMarkerCluster.svelte
+++ b/packages/map-next/src/lib/components/domain/map/SymbolMarkerCluster.svelte
@@ -44,11 +44,31 @@
 		clusterFeaturesPromise.then((f) => (clusterFeatures = f));
 	});
 
+	const ICON_SIZE = 30;
+	const MAX_ICONS = 10;
+
+	// Number of icons actually laid out (leaves are capped at MAX_ICONS below).
+	const iconCount = $derived(Math.min(clusterFeatures.length, MAX_ICONS));
+
+	// Radius of the ring the icons sit on; grows with the icon count.
+	function spreadRadius(total: number): number {
+		return 10 + (10 * total) / 3;
+	}
+
+	// Deep-green backdrop diameter, sized to sit behind the spread of icons.
+	const backdropSize = $derived(iconCount > 0 ? (spreadRadius(iconCount) + ICON_SIZE / 2) * 2 : 0);
+
+	// Total members in the cluster (may exceed the icons we render).
+	const pointCount = $derived<number>(Number(feature.properties?.point_count) || 0);
+	const pointCountLabel = $derived<string>(
+		(feature.properties?.point_count_abbreviated as string | undefined) ?? String(pointCount)
+	);
+
 	// Calculate circle positions for icons
 	function getCirclePosition(index: number, total: number): { x: number; y: number } {
 		if (index === 0 && total === 1) return { x: 0, y: 0 };
 
-		const radius = 10 + (10 * total) / 3; // Radius increases with number of points
+		const radius = spreadRadius(total); // Radius increases with number of points
 		const angle = (index * 2 * Math.PI) / total; // Evenly distribute around the circle
 
 		return {
@@ -58,12 +78,13 @@
 	}
 </script>
 
-<div class="cluster-container">
-	{#if clusterFeatures.length > 0}
-		{#each clusterFeatures.slice(0, 10) as clusterFeature, i (clusterFeature.properties.id)}
+<div class="cluster-container" style="--backdrop-size: {backdropSize}px">
+	{#if iconCount > 0}
+		<div class="cluster-backdrop"></div>
+		{#each clusterFeatures.slice(0, MAX_ICONS) as clusterFeature, i (clusterFeature.properties.id)}
 			{@const type = clusterFeature.properties?.type?.toLowerCase()}
 			{@const icon = getPlaceIcon(type)}
-			{@const position = getCirclePosition(i, Math.min(clusterFeatures.length, 10))}
+			{@const position = getCirclePosition(i, iconCount)}
 			<button
 				onclick={() => onMarkerClick(clusterFeature, { offset: [position.x, position.y] })}
 				class="cluster-icon-button"
@@ -76,6 +97,11 @@
 				/>
 			</button>
 		{/each}
+		{#if pointCount > 1}
+			<span class="cluster-count">
+				{pointCountLabel}
+			</span>
+		{/if}
 	{/if}
 </div>
 
@@ -87,6 +113,20 @@
 		justify-content: center;
 		width: 100px;
 		height: 100px;
+	}
+
+	/* Translucent deep-green disc sitting behind the grouped type icons. */
+	.cluster-backdrop {
+		position: absolute;
+		left: 50%;
+		top: 50%;
+		width: var(--backdrop-size);
+		height: var(--backdrop-size);
+		margin-left: calc(var(--backdrop-size) / -2);
+		margin-top: calc(var(--backdrop-size) / -2);
+		border-radius: 9999px;
+		background: var(--map-cluster-circle);
+		pointer-events: none;
 	}
 
 	.cluster-icon-button {
@@ -104,5 +144,31 @@
 		width: 30px;
 		height: 30px;
 		cursor: pointer;
+	}
+
+	/*
+	 * Coral count badge pinned to the top-right edge of the backdrop disc.
+	 * 0.354 ≈ cos(45°)/2 (= 1/(2√2)): projects the disc radius (--backdrop-size / 2)
+	 * onto the x/y axes to land the badge centre on the 45° edge of the circle.
+	 */
+	.cluster-count {
+		position: absolute;
+		left: calc(50% + var(--backdrop-size) * 0.354);
+		top: calc(50% - var(--backdrop-size) * 0.354);
+		transform: translate(-50%, -50%);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 18px;
+		height: 18px;
+		padding: 0 5px;
+		border-radius: 9999px;
+		background: var(--map-cluster-count);
+		color: var(--background);
+		font-family: var(--map-font-bold);
+		font-size: 11px;
+		line-height: 1;
+		font-weight: 700;
+		pointer-events: none;
 	}
 </style>

--- a/packages/map-next/src/lib/components/domain/map/SymbolMarkerLayer.svelte
+++ b/packages/map-next/src/lib/components/domain/map/SymbolMarkerLayer.svelte
@@ -12,9 +12,11 @@
 		minzoom?: number;
 		/** Entry ids to emphasize while a farm↔depot network is open (shared state). */
 		highlightedIds?: ReadonlySet<string>;
+		/** Hover key of the entry whose profile is open; its marker stays selected. */
+		selectedKey?: string | null;
 	}
 
-	let { onMarkerClick, minzoom, highlightedIds }: SymbolMarkerLayerProps = $props();
+	let { onMarkerClick, minzoom, highlightedIds, selectedKey }: SymbolMarkerLayerProps = $props();
 </script>
 
 <!-- Cluster markers -->
@@ -31,7 +33,9 @@
 		{#if entry}
 			{@const type = entry.properties.type.toLowerCase()}
 			{@const isNetworkHighlighted = highlightedIds?.has(entry.properties.id) ?? false}
-			{@const isHovered = hoveredEntry.key === entryHoverKey(entry.properties)}
+			{@const hoverKey = entryHoverKey(entry.properties)}
+			{@const isHovered = hoveredEntry.key === hoverKey}
+			{@const isSelected = selectedKey != null && selectedKey === hoverKey}
 			<button
 				type="button"
 				onclick={() => onMarkerClick(entry)}
@@ -42,7 +46,8 @@
 					class={cn(
 						'marker-icon',
 						isNetworkHighlighted && 'marker-icon--network',
-						isHovered && 'marker-icon--highlighted'
+						isHovered && 'marker-icon--highlighted',
+						isSelected && 'marker-icon--selected'
 					)}
 					src={getPlaceIcon(type)}
 					alt={entry.properties.name || type}
@@ -71,5 +76,16 @@
 	.marker-icon--network {
 		transform: scale(1.25);
 		filter: drop-shadow(0 0 4px var(--map-network-line));
+	}
+
+	/*
+	 * Selected marker: the entry whose profile is open. Scales up and gains a
+	 * salmon glow so it stays distinct until the profile closes. Takes precedence
+	 * over hover/network so an open profile always reads as the selected place.
+	 */
+	.marker-icon--selected {
+		transform: scale(1.45);
+		filter: drop-shadow(0 0 3px var(--map-marker-selected))
+			drop-shadow(0 2px 5px color-mix(in srgb, var(--foreground) 40%, transparent));
 	}
 </style>

--- a/packages/map-next/src/lib/design/theme-vars.css
+++ b/packages/map-next/src/lib/design/theme-vars.css
@@ -40,6 +40,7 @@
 	--base-color-map-base: #266050;
 	--base-color-map-place: #ffc8af;
 	--base-color-map-cluster: #ffa08c;
+	--base-color-map-cluster-count: #f4695b;
 	--base-color-map-network: #266050;
 
 	/* typography */
@@ -60,6 +61,12 @@
 	--map-place-primary: var(--base-color-map-place);
 	--map-place-secondary: var(--base-color-map-place);
 	--map-cluster-primary: var(--base-color-map-cluster);
+	/* Selected/hovered marker emphasis (spec F13) — salmon from the peach family. */
+	--map-marker-selected: var(--base-color-map-cluster);
+	/* Translucent deep-green backdrop behind grouped cluster icons. */
+	--map-cluster-circle: color-mix(in srgb, var(--base-color-map-base) 82%, transparent);
+	/* Coral cluster-count badge; distinct from --destructive. */
+	--map-cluster-count: var(--base-color-map-cluster-count);
 	--map-network-line: var(--base-color-map-network);
 	--map-network-line-width: 3;
 	--map-font-regular: var(--base-font-roboto-regular);
@@ -134,6 +141,7 @@
 	--base-color-map-base: #266050;
 	--base-color-map-place: #ffc8af;
 	--base-color-map-cluster: #ffa08c;
+	--base-color-map-cluster-count: #f4695b;
 	--base-color-map-network: #266050;
 	--base-color-chart-1: oklch(0.646 0.222 41.116);
 	--base-color-chart-2: oklch(0.6 0.118 184.704);
@@ -159,6 +167,12 @@
 	--map-place-primary: var(--base-color-map-place);
 	--map-place-secondary: var(--base-color-map-place);
 	--map-cluster-primary: var(--base-color-map-cluster);
+	/* Selected/hovered marker emphasis (spec F13) — salmon from the peach family. */
+	--map-marker-selected: var(--base-color-map-cluster);
+	/* Translucent deep-green backdrop behind grouped cluster icons. */
+	--map-cluster-circle: color-mix(in srgb, var(--base-color-map-base) 82%, transparent);
+	/* Coral cluster-count badge; distinct from --destructive. */
+	--map-cluster-count: var(--base-color-map-cluster-count);
 	--map-network-line: var(--base-color-map-network);
 	--map-network-line-width: 3;
 	--map-font-regular: var(--base-font-roboto-regular);

--- a/packages/map-next/src/routes/Map.svelte
+++ b/packages/map-next/src/routes/Map.svelte
@@ -21,6 +21,7 @@
 	import MapSidebar from './MapSidebar.svelte';
 	import { NetworkLayer, Popup, SymbolMarkerLayer } from '$lib/components/domain/map';
 	import { networkSelection } from '$lib/stores/network-selection.svelte';
+	import { entryHoverKey } from '$lib/stores/hovered-entry.svelte';
 	import { MAP_SIDEBAR_WIDTH_PX } from '$lib/config/layout';
 	import { asEntryFeature } from '$lib/utils/entry-features';
 	import {
@@ -130,6 +131,9 @@
 		}
 		return null;
 	});
+	// Hover key of the entry whose profile is open, so its marker stays visually
+	// selected until the profile closes (spec F13).
+	const selectedEntryKey = $derived(detailData ? entryHoverKey(detailData.properties) : null);
 	const highlightedNetworkIds = $derived.by<SvelteSet<string>>(() => {
 		const ids = new SvelteSet<string>();
 		if (networkFarm) {
@@ -566,6 +570,7 @@
 					onMarkerClick={handleMapEntryClick}
 					minzoom={9.5}
 					highlightedIds={highlightedNetworkIds}
+					selectedKey={selectedEntryKey}
 				/>
 			</GeoJSON>
 

--- a/specs/map-next-parity-ux/plan.md
+++ b/specs/map-next-parity-ux/plan.md
@@ -76,10 +76,10 @@ Status legend: [ ] todo · [~] in progress · [x] done
   - [ ] 12.2 Content sections separated by `Separator` with consistent `typography/` use; products/goals as chip clusters grouped by category instead of `list-disc` bullets.
   - [ ] 12.3 Back affordance in the slim persistent drawer header (from 10.2) restoring the previous list scroll position and viewport, in addition to close.
 
-- [ ] 13. Map visual language (depends on: none)
-  - [ ] 13.1 Distinct marker hover and selected states in `SymbolMarkerLayer`: selected marker scales/changes color and stays highlighted while its profile is open; hover feedback beyond cursor change.
-  - [ ] 13.2 Restyle cluster circles/count in `SymbolMarkerCluster` on the token palette.
-  - [ ] 13.3 Restyle `Popup.svelte` on card tokens (background/foreground, radius scale, shadow) replacing the 0.8-opacity dark box; verify in both themes; keep the zoom indicator dev-gated.
+- [x] 13. Map visual language (depends on: none)
+  - [x] 13.1 Distinct marker hover and selected states in `SymbolMarkerLayer`: selected marker scales/changes color and stays highlighted while its profile is open; hover feedback beyond cursor change.
+  - [x] 13.2 Restyle cluster circles/count in `SymbolMarkerCluster` on the token palette.
+  - [x] 13.3 Restyle `Popup.svelte` on card tokens (background/foreground, radius scale, shadow) replacing the 0.8-opacity dark box; verify in both themes; keep the zoom indicator dev-gated.
 
 - [ ] 14. App chrome & consistency pass (depends on: 5, 6, 10, 11, 12, 13)
   - [ ] 14.1 Decide and land the Track C token adjustments from `design-direction.md` (brand green `--primary`, cream panel background, coral cluster badge, serif-accent yes/no) in `theme-vars.css` + `DESIGN.md` + Storybook token stories; align all floating chrome (user nav pill, sidebar shell, map controls) on one radius/elevation scale.


### PR DESCRIPTION
Implements Feature 13 (Map visual language) of `specs/map-next-parity-ux`, restyling the map's markers, clusters, and popups on the design-token palette.

- **Selected marker**: the open profile's marker scales up with a salmon glow and stays highlighted until the profile closes (driven by a new `selectedKey` prop derived from `page.data.detailData`); hover keeps its scale + drop-shadow feedback.
- **Clusters**: a translucent deep-green backdrop disc sits behind the grouped type icons, with a coral count badge pinned to its edge.
- **Popups**: restyled as flat cards (card background/foreground tokens, app radius, soft shadow) replacing the 0.8-opacity dark box; verified in both themes.
- **Tokens**: added `--map-marker-selected`, `--map-cluster-circle`, and `--map-cluster-count` (coral) to both theme blocks; the zoom indicator stays dev-gated.

Verified: `npm run check` clean, 89 unit tests pass, prettier/eslint clean, and the map e2e suite (`depot-interaction`, `network-visualization`, `bottom-sheet`) green. Independent `/code-review` found no correctness bugs; two non-blocking cleanups (comment for the badge-positioning constant, hoisting `--backdrop-size` to the container) were applied. The now-dead `--map-popup` token chain and Colors.stories/DESIGN.md token documentation are intentionally deferred to Feature 14, which owns the token/DESIGN consistency pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)