### PR TITLE
fix(api): prevent account enumeration via authManagement reset/resend

### DIFF
--- a/packages/api/src/services/__test__/authManagement.test.js
+++ b/packages/api/src/services/__test__/authManagement.test.js
@@ -1,0 +1,73 @@
+import {
+  getTestDbConnectionString,
+  setupIntegrationTestDb,
+  truncateTestDb
+} from '../../../db/integrationTestSetup'
+import appLauncher from '../../app'
+import User from '../../models/users'
+import { createTestUser } from './data/users'
+
+jest.mock('../../hooks/email')
+jest.mock('../../hooks/authorization')
+// Stub the emails service so the reset notifier doesn't render templates in tests.
+jest.mock('../../services/emails', () => ({
+  __esModule: true,
+  default: (app) => app.use('/emails', { create: async () => ({}) })
+}))
+
+describe('authManagement enumeration protection', () => {
+  let app
+  beforeAll(async () => {
+    await setupIntegrationTestDb()
+    app = appLauncher.startApp({
+      postgres: {
+        client: 'pg',
+        connection: getTestDbConnectionString
+      }
+    })
+  })
+  afterEach(async () => {
+    await truncateTestDb()
+  })
+
+  const params = { provider: 'rest', headers: {}, query: {} }
+
+  const sendResetPwd = (email) =>
+    app
+      .service('authManagement')
+      .create({ action: 'sendResetPwd', value: { email } }, params)
+
+  it('returns a generic response for an unknown email (no "User not found")', async () => {
+    const result = await sendResetPwd(`missing-${Date.now()}@example.com`)
+    expect(result).toEqual({})
+  })
+
+  it('returns the same generic response for an existing (unverified) account', async () => {
+    const user = await createTestUser(app.service('users'), params)
+    const result = await sendResetPwd(user.email)
+    expect(result).toEqual({})
+  })
+
+  it('returns the same generic response for an existing verified account', async () => {
+    const user = await createTestUser(app.service('users'), params)
+    await User.query().findById(user.id).patch({ isVerified: true })
+    const result = await sendResetPwd(user.email)
+    expect(result).toEqual({})
+  })
+
+  it('is indistinguishable between existing and non-existing accounts', async () => {
+    const user = await createTestUser(app.service('users'), params)
+    const existing = await sendResetPwd(user.email)
+    const missing = await sendResetPwd(`missing-${Date.now()}@example.com`)
+    expect(existing).toEqual(missing)
+  })
+
+  it('does not leak account state via resendVerifySignup', async () => {
+    const data = {
+      action: 'resendVerifySignup',
+      value: { email: `missing-${Date.now()}@example.com` }
+    }
+    const result = await app.service('authManagement').create(data, params)
+    expect(result).toEqual({})
+  })
+})

--- a/packages/api/src/services/authManagement.js
+++ b/packages/api/src/services/authManagement.js
@@ -9,6 +9,38 @@ const isAction =
   (hook) =>
     args.includes(hook.data.action)
 
+// Guest-triggered actions that email the user. feathers-authentication-management
+// otherwise leaks account existence and verification state: an unknown email
+// throws "User not found.", a known-but-unverified one throws "User is not
+// verified.", and a verified one succeeds — a fully unauthenticated enumeration
+// oracle. For these actions we return an identical generic response whether the
+// account exists or not, and swallow (but log) the lookup error. The notifier
+// still fires only for real users.
+const GUEST_EMAIL_ACTIONS = ['sendResetPwd', 'resendVerifySignup']
+
+const isGuestEmailAction = (ctx) =>
+  GUEST_EMAIL_ACTIONS.includes(ctx.data && ctx.data.action)
+
+const genericResult = () => ({})
+
+const uniformGuestResponse = (ctx) => {
+  if (isGuestEmailAction(ctx)) {
+    ctx.result = genericResult()
+  }
+  return ctx
+}
+
+const suppressEnumerationError = (ctx) => {
+  if (isGuestEmailAction(ctx)) {
+    logger.info(
+      `authManagement '${ctx.data.action}' returned a generic response (enumeration guard); underlying result: ${ctx.error && ctx.error.message}`
+    )
+    ctx.error = null
+    ctx.result = genericResult()
+  }
+  return ctx
+}
+
 export default (app) => {
   app.configure(
     authManagement({
@@ -49,7 +81,10 @@ export default (app) => {
       ]
     },
     after: {
-      create: [filterAllowedFields]
+      create: [uniformGuestResponse, filterAllowedFields]
+    },
+    error: {
+      create: [suppressEnumerationError]
     }
   })
 }


### PR DESCRIPTION
## Summary

Closes the unauthenticated account-enumeration oracle in the password-reset / verification-resend flow. Follow-up to the security review (after #857 and the rate-limiting PR #859).

`feathers-authentication-management` returns three distinguishable responses to an anonymous caller depending on the account behind an email:

| Email state | Old response |
|---|---|
| not registered | `400 "User not found."` |
| registered, unverified | `400 "User is not verified."` |
| registered, verified | success |

So anyone could enumerate which emails are registered — and their verification state — by POSTing `{ action: 'sendResetPwd', value: { email } }` to `/authManagement` (a guest-accessible endpoint). `resendVerifySignup` has the same leak.

## Fix

For the two guest-triggered email actions (`sendResetPwd`, `resendVerifySignup`), always return an **identical generic response** regardless of whether the account exists or its verification state, and swallow the underlying lookup error (logged server-side). Implemented as:
- an `after` hook that normalizes the success result, and
- an `error` hook that converts the enumeration-revealing errors into the same generic result.

The reset/verify email notifier still fires only for real users, and `map-next`'s `recoverPassword` already discards the response body (it shows a generic "check your email"), so no client change is needed.

## Tests

New `authManagement.test.js` asserts unknown, unverified-existing, and verified-existing emails all yield the same generic response, plus a `resendVerifySignup` case. Full api suite green (10 suites, 79 passed).

## Deliberately out of scope

- **Login "User's email is not yet verified." message** (`authentication.js`). This fires only *after* a correct password, so it's a weak enumeration vector (the attacker already holds valid credentials), and the message is genuinely useful UX — a real user who hasn't verified needs to know why they can't log in. Removing it costs more than it protects, so I left it. Happy to change if you'd prefer strict uniformity.
- **Registration duplicate-email error** (POST `/users`). Enumeration here is largely unavoidable without a bigger UX change (deferred "check your inbox" flow); not addressed in this PR.
- **Timing side-channel**: real users do slightly more work (token write + notify) than unknown ones. The explicit message oracle is removed; fully constant-time behavior is a larger change and not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)