### PR TITLE
fix(map): read auth error response body once (fixes 'body stream already read')

### DIFF
--- a/packages/map/src/queries/clients.ts
+++ b/packages/map/src/queries/clients.ts
@@ -1,7 +1,7 @@
 import authentication from '@feathersjs/authentication-client'
 import { feathers } from '@feathersjs/feathers'
 import rest from '@feathersjs/rest-client'
-import { KyResponse } from 'ky'
+import ky, { Options } from 'ky'
 import config from '../configuration'
 import { ErrorResponse } from '../types/types.ts'
 
@@ -23,11 +23,34 @@ export class ApiResponseError extends Error {
   }
 }
 
-type KyErrorResponse = { response: KyResponse }
+/**
+ * POSTs JSON to the API and returns the parsed body, reading the response body
+ * exactly once. ky's `.json()` shortcut consumes the body when it throws on a
+ * non-2xx status, so the previous pattern (`ky.post(...).json()` then reading
+ * `error.response.json()` in the catch) failed with "body stream already read"
+ * and masked the real server error. `throwHttpErrors: false` lets us read the
+ * body once and surface the server's message.
+ */
+export async function postJson<T = unknown>(
+  url: string,
+  options: Options = {}
+): Promise<T | undefined> {
+  const response = await ky.post(url, { ...options, throwHttpErrors: false })
 
-export async function throwApiError(error: unknown) {
-  const { message, code } = (await (
-    error as KyErrorResponse
-  ).response.json()) as ErrorResponse
-  throw new ApiResponseError(message, code)
+  let body: (ErrorResponse & Record<string, unknown>) | undefined
+  try {
+    body = await response.json()
+  } catch {
+    // No JSON body (e.g. empty 2xx response).
+    body = undefined
+  }
+
+  if (!response.ok) {
+    throw new ApiResponseError(
+      body?.message ?? 'Request failed',
+      body?.code ?? response.status
+    )
+  }
+
+  return body as T | undefined
 }

--- a/packages/map/src/queries/users.api.ts
+++ b/packages/map/src/queries/users.api.ts
@@ -1,9 +1,7 @@
 import _ from 'lodash'
 
-// TODO replace client with plain fetch
-import ky from 'ky'
 import configuration from '../configuration.ts'
-import { client, throwApiError } from './clients'
+import { client, postJson } from './clients'
 
 const { apiBaseUrl } = configuration
 
@@ -72,22 +70,15 @@ export async function updateUserPassword(
   updateUserPasswordParams: UpdateUserPasswordParams
 ) {
   const { oldPassword, password, email } = updateUserPasswordParams
-  try {
-    return await ky
-      .post(`${apiBaseUrl}/authManagement`, {
-        headers: {
-          Authorization: `Bearer ${await client.authentication.getAccessToken()}`
-        },
-        json: {
-          action: 'passwordChange',
-          value: { user: { email }, oldPassword, password }
-        }
-      })
-      .json()
-  } catch (error) {
-    const errorResponse = await error.response.json()
-    throw new Error(errorResponse.message)
-  }
+  return postJson(`${apiBaseUrl}/authManagement`, {
+    headers: {
+      Authorization: `Bearer ${await client.authentication.getAccessToken()}`
+    },
+    json: {
+      action: 'passwordChange',
+      value: { user: { email }, oldPassword, password }
+    }
+  })
 }
 
 export interface RecoverUserPasswordParams {
@@ -97,18 +88,12 @@ export interface RecoverUserPasswordParams {
 export async function recoverUserPassword(
   recoverPasswordParams: RecoverUserPasswordParams
 ) {
-  try {
-    return await ky
-      .post(`${apiBaseUrl}/authManagement`, {
-        json: {
-          action: 'sendResetPwd',
-          value: recoverPasswordParams
-        }
-      })
-      .json()
-  } catch (error) {
-    await throwApiError(error)
-  }
+  return postJson(`${apiBaseUrl}/authManagement`, {
+    json: {
+      action: 'sendResetPwd',
+      value: recoverPasswordParams
+    }
+  })
 }
 
 interface ResetUserPasswordParams {
@@ -120,18 +105,12 @@ export async function resetUserPassword(
   resetUserPasswordParams: ResetUserPasswordParams
 ) {
   const { resetPasswordToken, password } = resetUserPasswordParams
-  try {
-    return await ky
-      .post(`${apiBaseUrl}/authManagement`, {
-        json: {
-          action: 'resetPwdLong',
-          value: { token: resetPasswordToken, password }
-        }
-      })
-      .json()
-  } catch (error) {
-    await throwApiError(error)
-  }
+  return postJson(`${apiBaseUrl}/authManagement`, {
+    json: {
+      action: 'resetPwdLong',
+      value: { token: resetPasswordToken, password }
+    }
+  })
 }
 
 export interface ConfirmUserParams {
@@ -140,15 +119,9 @@ export interface ConfirmUserParams {
 
 export async function confirmUser(confirmUserParams: ConfirmUserParams) {
   const { confirmationToken } = confirmUserParams
-  try {
-    return await ky
-      .post(`${apiBaseUrl}/authManagement`, {
-        json: { action: 'verifySignupLong', value: confirmationToken }
-      })
-      .json()
-  } catch (error) {
-    await throwApiError(error)
-  }
+  return postJson(`${apiBaseUrl}/authManagement`, {
+    json: { action: 'verifySignupLong', value: confirmationToken }
+  })
 }
 
 export interface ReactivateUserParams {
@@ -160,13 +133,7 @@ export async function reactivateUser(
   reactivateUserParams: ReactivateUserParams
 ) {
   const { id, token } = reactivateUserParams
-  try {
-    return await ky
-      .post(`${apiBaseUrl}/user-reactivation`, {
-        json: { id, token }
-      })
-      .json()
-  } catch (error) {
-    await throwApiError(error)
-  }
+  return postJson(`${apiBaseUrl}/user-reactivation`, {
+    json: { id, token }
+  })
 }


### PR DESCRIPTION
## Summary

Fixes the `Failed to execute 'json' on 'Response': body stream already read` error seen on staging when doing a password reset in the legacy `packages/map` frontend.

## Root cause (not a regression)

Legacy map's authManagement calls did:

```js
try {
  return await ky.post(url, { json: {...} }).json()   // ky's .json() shortcut
} catch (error) {
  await throwApiError(error)                            // reads error.response.json()
}
```

`ky@2` **consumes the response body when it throws on a non-2xx status**, so the second read in the catch fails with "body stream already read" — which then masks the real server error. I confirmed this against a local server: `ky.post().json()` then `error.response.json()` → *"Body has already been read"*, whereas `throwHttpErrors: false` + a single read returns the body fine.

Password reset triggers a 4xx whenever the email isn't registered or isn't verified (unchanged API behavior — verified: 201, unknown/unverified: 400), so every such reset hit this. **None of the recent API PRs caused it**; the enumeration fix (#860, not yet deployed) would actually mask it by returning 201.

## Fix

Replace `throwApiError` with a `postJson()` helper in `clients.ts` that sets `throwHttpErrors: false` and reads the response body **exactly once**, throwing an `ApiResponseError` with the real server message on failure. Routed all the affected calls through it: `recoverUserPassword`, `resetUserPassword`, `confirmUser`, `reactivateUser`, and `updateUserPassword` (which had the same inline double-read).

## Notes

- `packages/map` is being retired in favor of `map-next`, whose HTTP client already reads the error body once and isn't affected. This is a minimal fix to keep the legacy flow usable on staging until the switch.
- No unit-test infra in `packages/map` (Playwright e2e only); verified the ky behavior with a standalone probe and `tsc` is clean for the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)