### PR TITLE
feat(map-next): contact form as its own drawer view

### DIFF
--- a/packages/map-next/e2e/contact-drawer.test.ts
+++ b/packages/map-next/e2e/contact-drawer.test.ts
@@ -1,0 +1,126 @@
+import { expect, test, type Page, type Route } from '@playwright/test';
+
+// Feature 5: "Kontakt aufnehmen" opens a dedicated contact drawer view rather
+// than appending the form to the profile. This covers session prefill, the
+// owner-hidden CTA, and back-navigation to the profile.
+
+async function fulfillJson(route: Route, body: unknown) {
+	await route.fulfill({
+		status: 200,
+		contentType: 'application/json',
+		body: JSON.stringify(body)
+	});
+}
+
+function farmDetail(id: string, name: string) {
+	return {
+		type: 'Feature',
+		geometry: { type: 'Point', coordinates: [8.55, 47.38] },
+		properties: {
+			id,
+			type: 'Farm',
+			name,
+			city: 'Test City',
+			postalcode: '8000',
+			state: 'ZH',
+			country: 'CH',
+			link: 'https://example.com',
+			description: 'Farm details',
+			badges: [],
+			products: []
+		}
+	};
+}
+
+function ownedFarmMarker(id: string, name: string) {
+	return {
+		type: 'Feature',
+		geometry: { type: 'Point', coordinates: [8.55, 47.38] },
+		properties: {
+			id,
+			type: 'Farm',
+			name,
+			postalcode: '8000',
+			city: 'Test City',
+			state: 'ZH',
+			country: 'CH',
+			link: 'https://example.com',
+			products: [],
+			updatedAt: '2025-02-01T00:00:00.000Z'
+		}
+	};
+}
+
+async function mockAuthenticatedUser(page: Page) {
+	await page.addInitScript(() => {
+		window.localStorage.setItem('accessToken', 'test-token');
+	});
+	await page.route(/\/authentication(?:\/)?(?:\?.*)?$/, (route) =>
+		fulfillJson(route, {
+			accessToken: 'test-token',
+			user: { id: 'user-1', email: 'owner@example.com', name: 'Owner User' }
+		})
+	);
+}
+
+// `ownedIds` are returned as the user's own entries (`mine=true`); everything
+// else is public. A farm detail is served for any /farms/:id request.
+async function mockEntries(page: Page, ownedIds: string[]) {
+	await page.route(/\/entries(?:\/)?(?:\?.*)?$/, (route) => {
+		const url = new URL(route.request().url());
+		if (url.searchParams.get('mine') === 'true') {
+			return fulfillJson(route, {
+				type: 'FeatureCollection',
+				features: ownedIds.map((id) => ownedFarmMarker(id, `Owned ${id}`))
+			});
+		}
+		return fulfillJson(route, {
+			type: 'FeatureCollection',
+			features: [ownedFarmMarker('public-farm', 'Public Farm')]
+		});
+	});
+	await page.route(/\/farms\/[^/?]+(?:\?.*)?$/, (route) => {
+		const id = route.request().url().split('/farms/')[1].split('?')[0].split('#')[0];
+		return fulfillJson(route, farmDetail(id, id === 'public-farm' ? 'Public Farm' : `Owned ${id}`));
+	});
+}
+
+test('contact view prefills name/email from the session and back returns to the profile', async ({
+	page
+}) => {
+	await mockAuthenticatedUser(page);
+	await mockEntries(page, []); // user owns nothing → CTA shows on the public farm
+
+	await page.goto('/#/farms/public-farm');
+	await expect(page.getByRole('heading', { name: 'Public Farm' })).toBeVisible({ timeout: 15000 });
+
+	await page.getByTestId('entry-contact-toggle').click();
+
+	// Entry name stays visible in the contact view header, fields are prefilled.
+	await expect(page.getByRole('heading', { name: 'Public Farm' })).toBeVisible();
+	await expect(page.locator('#entry-contact-sender-name')).toHaveValue('Owner User');
+	await expect(page.locator('#entry-contact-sender-email')).toHaveValue('owner@example.com');
+
+	// Prefilled fields remain editable.
+	await page.locator('#entry-contact-sender-name').fill('Someone Else');
+	await expect(page.locator('#entry-contact-sender-name')).toHaveValue('Someone Else');
+
+	// Back returns to the profile (contact form unmounted, sections back).
+	await page.getByTestId('entry-contact-back').click();
+	await expect(page.getByTestId('entry-contact-form')).toBeHidden();
+	await expect(page.getByTestId('entry-contact-toggle')).toBeVisible();
+});
+
+test('contact CTA is hidden on an entry the current account owns', async ({ page }) => {
+	await mockAuthenticatedUser(page);
+	await mockEntries(page, ['my-farm']); // user owns this farm
+
+	await page.goto('/#/farms/my-farm');
+	await expect(page.getByRole('heading', { name: 'Owned my-farm' })).toBeVisible({
+		timeout: 15000
+	});
+
+	// Owners edit rather than contact themselves: the CTA is absent, Edit present.
+	await expect(page.getByTestId('entry-detail-edit')).toBeVisible();
+	await expect(page.getByTestId('entry-contact-toggle')).toHaveCount(0);
+});

--- a/packages/map-next/e2e/contact-drawer.test.ts
+++ b/packages/map-next/e2e/contact-drawer.test.ts
@@ -124,3 +124,39 @@ test('contact CTA is hidden on an entry the current account owns', async ({ page
 	await expect(page.getByTestId('entry-detail-edit')).toBeVisible();
 	await expect(page.getByTestId('entry-contact-toggle')).toHaveCount(0);
 });
+
+test('contact view is force-closed once ownership resolves for an owner', async ({ page }) => {
+	await mockAuthenticatedUser(page);
+
+	// Ownership resolves async: the owned-entries (mine=true) response is delayed so
+	// `canEdit` starts false and the CTA is briefly available on the owner's own farm.
+	await page.route(/\/entries(?:\/)?(?:\?.*)?$/, async (route) => {
+		const url = new URL(route.request().url());
+		if (url.searchParams.get('mine') === 'true') {
+			await new Promise((resolve) => setTimeout(resolve, 1500));
+			return fulfillJson(route, {
+				type: 'FeatureCollection',
+				features: [ownedFarmMarker('race-farm', 'Owned race-farm')]
+			});
+		}
+		return fulfillJson(route, { type: 'FeatureCollection', features: [] });
+	});
+	await page.route(/\/farms\/[^/?]+(?:\?.*)?$/, (route) =>
+		fulfillJson(route, farmDetail('race-farm', 'Owned race-farm'))
+	);
+
+	await page.goto('/#/farms/race-farm');
+	await expect(page.getByRole('heading', { name: 'Owned race-farm' })).toBeVisible({
+		timeout: 15000
+	});
+
+	// Before ownership resolves the CTA is available; open the contact view.
+	await page.getByTestId('entry-contact-toggle').click();
+	await expect(page.getByTestId('entry-contact-form')).toBeVisible();
+
+	// Once myEntries resolves, `canEdit` flips true and the contact view is
+	// unmounted (owners cannot message themselves); the Edit action appears.
+	await expect(page.getByTestId('entry-contact-form')).toBeHidden({ timeout: 15000 });
+	await expect(page.getByTestId('entry-contact-toggle')).toHaveCount(0);
+	await expect(page.getByTestId('entry-detail-edit')).toBeVisible();
+});

--- a/packages/map-next/e2e/contact-token-feedback.test.ts
+++ b/packages/map-next/e2e/contact-token-feedback.test.ts
@@ -85,7 +85,7 @@ test('reactivation token in hash query shows inline error banner and clears para
 		.not.toContain('reactivation_token=invalid');
 });
 
-test('farm detail contact form sends entrycontactmessage and shows inline success', async ({
+test('farm detail contact form sends entrycontactmessage, toasts, and returns to the profile', async ({
 	page
 }) => {
 	await mockBaseEntries(page);
@@ -109,13 +109,23 @@ test('farm detail contact form sends entrycontactmessage and shows inline succes
 	await page.goto('/#/farms/24');
 	await expect(page.getByRole('heading', { name: 'Farm 24' })).toBeVisible({ timeout: 15000 });
 
+	// The CTA opens a dedicated contact view (Feature 5): the profile sections are
+	// replaced, the entry name stays visible in the header, and a back button returns.
 	await page.getByTestId('entry-contact-toggle').click();
+	await expect(page.getByTestId('entry-contact-form')).toBeVisible();
+	await expect(page.getByTestId('entry-contact-back')).toBeVisible();
+
 	await page.locator('#entry-contact-sender-name').fill('Jane');
 	await page.locator('#entry-contact-sender-email').fill('jane@example.com');
 	await page.getByTestId('entry-contact-message').fill('Hello from browser test');
 	await page.getByTestId('entry-contact-submit').click();
 
-	await expect(page.getByTestId('entry-contact-success')).toBeVisible({ timeout: 15000 });
+	// Success: a sonner toast and a return to the profile (contact form unmounted).
+	await expect(
+		page.locator('[data-sonner-toast]').filter({ hasText: 'Deine Nachricht wurde gesendet.' })
+	).toBeVisible({ timeout: 15000 });
+	await expect(page.getByTestId('entry-contact-form')).toBeHidden();
+	await expect(page.getByRole('heading', { name: 'Farm 24' })).toBeVisible();
 	expect(contactPayload).toEqual({
 		id: '24',
 		type: 'Farm',

--- a/packages/map-next/messages/de-at.json
+++ b/packages/map-next/messages/de-at.json
@@ -264,6 +264,7 @@
 	"entry_contact_sending": "Wird gesendet...",
 	"entry_contact_success": "Deine Nachricht wurde gesendet.",
 	"entry_contact_error": "Deine Nachricht konnte nicht gesendet werden.",
+	"entry_contact_back": "Zurück zum Eintrag",
 	"entry_share_action": "Link kopieren",
 	"entry_share_copied": "Link in die Zwischenablage kopiert.",
 	"entry_share_failed": "Link konnte nicht kopiert werden.",

--- a/packages/map-next/messages/de-ch.json
+++ b/packages/map-next/messages/de-ch.json
@@ -264,6 +264,7 @@
 	"entry_contact_sending": "Wird gesendet...",
 	"entry_contact_success": "Deine Nachricht wurde gesendet.",
 	"entry_contact_error": "Deine Nachricht konnte nicht gesendet werden.",
+	"entry_contact_back": "Zurück zum Eintrag",
 	"entry_share_action": "Link kopieren",
 	"entry_share_copied": "Link in die Zwischenablage kopiert.",
 	"entry_share_failed": "Link konnte nicht kopiert werden.",

--- a/packages/map-next/messages/de-de.json
+++ b/packages/map-next/messages/de-de.json
@@ -264,6 +264,7 @@
 	"entry_contact_sending": "Wird gesendet...",
 	"entry_contact_success": "Deine Nachricht wurde gesendet.",
 	"entry_contact_error": "Deine Nachricht konnte nicht gesendet werden.",
+	"entry_contact_back": "Zurück zum Eintrag",
 	"entry_share_action": "Link kopieren",
 	"entry_share_copied": "Link in die Zwischenablage kopiert.",
 	"entry_share_failed": "Link konnte nicht kopiert werden.",

--- a/packages/map-next/messages/fr-ch.json
+++ b/packages/map-next/messages/fr-ch.json
@@ -264,6 +264,7 @@
 	"entry_contact_sending": "Envoi en cours...",
 	"entry_contact_success": "Votre message a été envoyé.",
 	"entry_contact_error": "Votre message n'a pas pu être envoyé.",
+	"entry_contact_back": "Retour à l'entrée",
 	"entry_share_action": "Copier le lien",
 	"entry_share_copied": "Lien copié dans le presse-papiers.",
 	"entry_share_failed": "Le lien n'a pas pu être copié.",

--- a/packages/map-next/src/lib/components/domain/entries/EntryContactForm.svelte
+++ b/packages/map-next/src/lib/components/domain/entries/EntryContactForm.svelte
@@ -10,12 +10,30 @@
 	interface EntryContactFormProps {
 		entryId: string;
 		entryType: MainEntryType;
+		/** Prefill the sender fields (e.g. from the authenticated session); stays editable. */
+		initialName?: string;
+		initialEmail?: string;
+		/**
+		 * Called after a message is sent successfully. When provided, the parent owns
+		 * the success feedback (toast + navigation) and no inline success alert renders.
+		 */
+		onSent?: () => void;
 	}
 
-	let { entryId, entryType }: EntryContactFormProps = $props();
+	let {
+		entryId,
+		entryType,
+		initialName = '',
+		initialEmail = '',
+		onSent
+	}: EntryContactFormProps = $props();
 
-	let senderName = $state('');
-	let senderEmail = $state('');
+	// Prefilled from props (session) but freely editable afterwards; the component is
+	// remounted per contact view so initialising state directly from props is safe.
+	// svelte-ignore state_referenced_locally
+	let senderName = $state(initialName);
+	// svelte-ignore state_referenced_locally
+	let senderEmail = $state(initialEmail);
 	let messageText = $state('');
 	let isSubmitting = $state(false);
 	let successMessage = $state<string | null>(null);
@@ -60,8 +78,13 @@
 				senderEmail: senderEmail.trim(),
 				text: messageText.trim()
 			});
-			successMessage = m.entry_contact_success();
 			messageText = '';
+			if (onSent) {
+				// Parent handles success feedback (toast) and returns to the profile.
+				onSent();
+			} else {
+				successMessage = m.entry_contact_success();
+			}
 		} catch (error) {
 			errorMessage = error instanceof Error ? error.message : m.entry_contact_error();
 		} finally {

--- a/packages/map-next/src/lib/components/domain/entries/EntryContactView.svelte
+++ b/packages/map-next/src/lib/components/domain/entries/EntryContactView.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left';
+	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
+	import { IconButton } from '$lib/components/actions';
+	import EntryContactForm from './EntryContactForm.svelte';
+	import { toastSuccess } from '$lib/utils/toast';
+	import type { MainEntryType } from '$lib/types/entries';
+	import * as m from '$lib/paraglide/messages.js';
+
+	interface EntryContactViewProps {
+		entryId: string;
+		entryType: MainEntryType;
+		/** Shown in the header so the sender knows which entry they are contacting. */
+		entryName: string;
+		/** Prefill values (from the authenticated session); fields stay editable. */
+		initialName?: string;
+		initialEmail?: string;
+		/** Return to the profile view (Feature 5: the contact view replaces it). */
+		onBack: () => void;
+	}
+
+	let {
+		entryId,
+		entryType,
+		entryName,
+		initialName = '',
+		initialEmail = '',
+		onBack
+	}: EntryContactViewProps = $props();
+
+	// A successful send returns to the profile with a toast (F5.4); the profile
+	// remounts scrolled to the top (top-scroll on return, per plan task 5.1).
+	function handleSent() {
+		toastSuccess(m.entry_contact_success());
+		onBack();
+	}
+</script>
+
+<Sidebar.Header class="border-b">
+	<div class="flex items-center gap-2">
+		<IconButton
+			class="shrink-0 max-md:size-11"
+			data-testid="entry-contact-back"
+			label={m.entry_contact_back()}
+			onclick={onBack}
+		>
+			<ArrowLeftIcon />
+		</IconButton>
+		<h2 class="min-w-0 flex-1 truncate text-lg leading-tight font-semibold text-foreground">
+			{entryName}
+		</h2>
+	</div>
+</Sidebar.Header>
+
+<Sidebar.Content class="overflow-y-auto">
+	<div class="p-4">
+		<EntryContactForm {entryId} {entryType} {initialName} {initialEmail} onSent={handleSent} />
+	</div>
+</Sidebar.Content>

--- a/packages/map-next/src/lib/components/domain/entries/index.ts
+++ b/packages/map-next/src/lib/components/domain/entries/index.ts
@@ -2,6 +2,7 @@ import BadgesList from './BadgesList.svelte';
 import EntriesList from './EntriesList.svelte';
 import EntryCard from './EntryCard.svelte';
 import EntryContactForm from './EntryContactForm.svelte';
+import EntryContactView from './EntryContactView.svelte';
 import EntryCreationWizard from './EntryCreationWizard.svelte';
 import EntryRowActions from './EntryRowActions.svelte';
 import MembershipStatus from './MembershipStatus.svelte';
@@ -17,6 +18,7 @@ export {
 	EntriesList,
 	EntryCard,
 	EntryContactForm,
+	EntryContactView,
 	EntryCreationWizard,
 	EntryRowActions,
 	MembershipStatus,

--- a/packages/map-next/src/lib/components/domain/farms/FarmProfile.svelte
+++ b/packages/map-next/src/lib/components/domain/farms/FarmProfile.svelte
@@ -190,7 +190,10 @@
 	);
 </script>
 
-{#if mode === 'read' && showContactForm && properties}
+<!-- `!canEdit` also gates the view (not just the CTA): ownership resolves async
+     (myEntries load), so an owner can open contact before `canEdit` flips true —
+     re-checking here unmounts the view the moment ownership is known (F5.3). -->
+{#if mode === 'read' && showContactForm && properties && !canEdit}
 	<EntryContactView
 		entryId={properties.id}
 		entryType="Farm"

--- a/packages/map-next/src/lib/components/domain/farms/FarmProfile.svelte
+++ b/packages/map-next/src/lib/components/domain/farms/FarmProfile.svelte
@@ -8,12 +8,13 @@
 	import { Paragraph } from '$lib/components/typography';
 	import { EditorAccountInfo, EditorSaveBar, FormInput } from '$lib/components/forms';
 	import {
-		EntryContactForm,
+		EntryContactView,
 		MembershipStatus,
 		IdentitySection,
 		DescriptionSection,
 		BadgesSection
 	} from '$lib/components/domain/entries';
+	import { authStore } from '$lib/stores/auth.svelte';
 	import { formatFoundedLine } from '$lib/utils/entry-format';
 	import { copyProfileLink } from '$lib/utils/share';
 	import {
@@ -124,7 +125,11 @@
 		hasUnsavedChanges: () => hasUnsavedChanges
 	});
 
+	// Feature 5: the contact CTA opens a dedicated drawer view (not an appended
+	// section). Sender fields prefill from the session but stay editable.
 	let showContactForm = $state(false);
+	const contactPrefillName = $derived(authStore.user?.name ?? '');
+	const contactPrefillEmail = $derived(authStore.user?.email ?? '');
 
 	async function handleSubmit() {
 		if (isSaving) {
@@ -185,136 +190,145 @@
 	);
 </script>
 
-<Sidebar.Header class="border-b">
-	<div class="flex items-start justify-between gap-2">
-		<div class="flex min-w-0 flex-1 items-start gap-3">
-			<div class="mt-1 shrink-0 text-muted-foreground">
-				<img class="size-9 object-contain" src={icon} alt={title} />
+{#if mode === 'read' && showContactForm && properties}
+	<EntryContactView
+		entryId={properties.id}
+		entryType="Farm"
+		entryName={properties.name}
+		initialName={contactPrefillName}
+		initialEmail={contactPrefillEmail}
+		onBack={() => (showContactForm = false)}
+	/>
+{:else}
+	<Sidebar.Header class="border-b">
+		<div class="flex items-start justify-between gap-2">
+			<div class="flex min-w-0 flex-1 items-start gap-3">
+				<div class="mt-1 shrink-0 text-muted-foreground">
+					<img class="size-9 object-contain" src={icon} alt={title} />
+				</div>
+				<div class="flex min-w-0 flex-1 flex-col gap-1">
+					{#if mode === 'edit'}
+						<FormInput
+							id="entry-editor-name"
+							data-testid="editor-input-name"
+							label={m.editor_field_name()}
+							required
+							bind:value={$formData.name}
+							error={$errors.name}
+						/>
+					{:else}
+						<h2 class="text-lg leading-tight font-semibold text-foreground">{properties?.name}</h2>
+						{#if foundedLine}
+							<Paragraph size="small" muted>{foundedLine}</Paragraph>
+						{/if}
+						{#if acceptsNewMembers}
+							<MembershipStatus {acceptsNewMembers} detailed />
+						{/if}
+					{/if}
+				</div>
 			</div>
-			<div class="flex min-w-0 flex-1 flex-col gap-1">
+			<div class="flex shrink-0 items-center gap-1">
 				{#if mode === 'edit'}
-					<FormInput
-						id="entry-editor-name"
-						data-testid="editor-input-name"
-						label={m.editor_field_name()}
-						required
-						bind:value={$formData.name}
-						error={$errors.name}
-					/>
+					<AppButton
+						type="button"
+						variant="outline"
+						data-testid="entry-editor-cancel"
+						onclick={() => void handleCancel()}
+					>
+						{m.editor_cancel()}
+					</AppButton>
 				{:else}
-					<h2 class="text-lg leading-tight font-semibold text-foreground">{properties?.name}</h2>
-					{#if foundedLine}
-						<Paragraph size="small" muted>{foundedLine}</Paragraph>
+					{#if canEdit && onEdit}
+						<AppButton variant="outline" data-testid="entry-detail-edit" onclick={onEdit}>
+							{m.map_sidebar_action_edit()}
+						</AppButton>
 					{/if}
-					{#if acceptsNewMembers}
-						<MembershipStatus {acceptsNewMembers} detailed />
-					{/if}
+					<IconButton
+						class="shrink-0"
+						data-testid="entry-detail-share"
+						label={m.entry_share_action()}
+						onclick={() => void handleShare()}
+					>
+						<LinkIcon />
+					</IconButton>
+					<IconButton
+						class="shrink-0"
+						data-testid="entry-detail-close"
+						label={m.map_token_feedback_dismiss()}
+						onclick={onClose}
+					>
+						<XIcon />
+					</IconButton>
 				{/if}
 			</div>
 		</div>
-		<div class="flex shrink-0 items-center gap-1">
-			{#if mode === 'edit'}
-				<AppButton
-					type="button"
-					variant="outline"
-					data-testid="entry-editor-cancel"
-					onclick={() => void handleCancel()}
-				>
-					{m.editor_cancel()}
-				</AppButton>
-			{:else}
-				{#if canEdit && onEdit}
-					<AppButton variant="outline" data-testid="entry-detail-edit" onclick={onEdit}>
-						{m.map_sidebar_action_edit()}
-					</AppButton>
-				{/if}
-				<IconButton
-					class="shrink-0"
-					data-testid="entry-detail-share"
-					label={m.entry_share_action()}
-					onclick={() => void handleShare()}
-				>
-					<LinkIcon />
-				</IconButton>
-				<IconButton
-					class="shrink-0"
-					data-testid="entry-detail-close"
-					label={m.map_token_feedback_dismiss()}
-					onclick={onClose}
-				>
-					<XIcon />
-				</IconButton>
-			{/if}
-		</div>
-	</div>
-</Sidebar.Header>
+	</Sidebar.Header>
 
-<Sidebar.Content class="overflow-y-auto">
-	{#if mode === 'edit'}
-		<form
-			class="flex flex-col gap-4 p-4 pb-24"
-			data-testid="entry-editor"
-			onsubmit={handleFormSubmit}
-		>
-			<Paragraph size="small">{m.user_form_required_fields()}</Paragraph>
+	<Sidebar.Content class="overflow-y-auto">
+		{#if mode === 'edit'}
+			<form
+				class="flex flex-col gap-4 p-4 pb-24"
+				data-testid="entry-editor"
+				onsubmit={handleFormSubmit}
+			>
+				<Paragraph size="small">{m.user_form_required_fields()}</Paragraph>
 
-			<IdentitySection mode="edit" {form} markerType="Farm" />
-			<DescriptionSection mode="edit" {form} />
-			<EditorAccountInfo />
-			<FarmProductsSection mode="edit" {form} {products} />
-			<FarmEconomicBehaviorSection mode="edit" {form} />
-			<FarmMembershipSection mode="edit" {form} />
-			<BadgesSection mode="edit" {form} {badges} idPrefix="farm-badge" />
-			<FarmDepotsSection
-				{properties}
-				{ownedDepotIds}
-				isFarmOwner={canEdit}
-				{onDepotSelect}
-				{onDepotEdit}
-				{onDepotDelete}
-				{onAddDepot}
-			/>
+				<IdentitySection mode="edit" {form} markerType="Farm" />
+				<DescriptionSection mode="edit" {form} />
+				<EditorAccountInfo />
+				<FarmProductsSection mode="edit" {form} {products} />
+				<FarmEconomicBehaviorSection mode="edit" {form} />
+				<FarmMembershipSection mode="edit" {form} />
+				<BadgesSection mode="edit" {form} {badges} idPrefix="farm-badge" />
+				<FarmDepotsSection
+					{properties}
+					{ownedDepotIds}
+					isFarmOwner={canEdit}
+					{onDepotSelect}
+					{onDepotEdit}
+					{onDepotDelete}
+					{onAddDepot}
+				/>
 
-			<EditorSaveBar {isSaving} {sectionErrors} onCancel={() => void handleCancel()} />
-		</form>
-	{:else}
-		<!-- `divide-y` draws separators only between rendered sections; empty
+				<EditorSaveBar {isSaving} {sectionErrors} onCancel={() => void handleCancel()} />
+			</form>
+		{:else}
+			<!-- `divide-y` draws separators only between rendered sections; empty
 		     sections render no element, so no stray dividers appear (F12.2). -->
-		<div
-			class="flex flex-col divide-y divide-border p-4 [&>*]:py-4 [&>*:first-child]:pt-0 [&>*:last-child]:pb-0"
-		>
-			<IdentitySection mode="read" {properties} {form} markerType="Farm" />
-			<DescriptionSection mode="read" {properties} {form} />
-			<FarmProductsSection mode="read" {properties} {form} />
-			<FarmEconomicBehaviorSection mode="read" {properties} {form} />
-			<FarmMembershipSection mode="read" {properties} {form} />
-			<BadgesSection mode="read" {properties} {form} idPrefix="farm-badge" />
-			<FarmDepotsSection
-				{properties}
-				{ownedDepotIds}
-				isFarmOwner={canEdit}
-				{onDepotSelect}
-				{onDepotEdit}
-				{onDepotDelete}
-				{onAddDepot}
-			/>
+			<div
+				class="flex flex-col divide-y divide-border p-4 [&>*]:py-4 [&>*:first-child]:pt-0 [&>*:last-child]:pb-0"
+			>
+				<IdentitySection mode="read" {properties} {form} markerType="Farm" />
+				<DescriptionSection mode="read" {properties} {form} />
+				<FarmProductsSection mode="read" {properties} {form} />
+				<FarmEconomicBehaviorSection mode="read" {properties} {form} />
+				<FarmMembershipSection mode="read" {properties} {form} />
+				<BadgesSection mode="read" {properties} {form} idPrefix="farm-badge" />
+				<FarmDepotsSection
+					{properties}
+					{ownedDepotIds}
+					isFarmOwner={canEdit}
+					{onDepotSelect}
+					{onDepotEdit}
+					{onDepotDelete}
+					{onAddDepot}
+				/>
+			</div>
+		{/if}
+	</Sidebar.Content>
 
-			{#if properties && showContactForm}
-				<EntryContactForm entryId={properties.id} entryType="Farm" />
-			{/if}
-		</div>
+	<!-- Feature 5.3: the CTA is hidden on entries the current account owns
+	     (`canEdit`), who edit rather than contact themselves. -->
+	{#if mode === 'read' && properties && !canEdit}
+		<Sidebar.Footer class="border-t p-4">
+			<AppButton
+				type="button"
+				class="w-full"
+				data-testid="entry-contact-toggle"
+				onclick={() => (showContactForm = true)}
+			>
+				{m.entry_contact_button()}
+			</AppButton>
+		</Sidebar.Footer>
 	{/if}
-</Sidebar.Content>
-
-{#if mode === 'read' && properties && !showContactForm}
-	<Sidebar.Footer class="border-t p-4">
-		<AppButton
-			type="button"
-			class="w-full"
-			data-testid="entry-contact-toggle"
-			onclick={() => (showContactForm = true)}
-		>
-			{m.entry_contact_button()}
-		</AppButton>
-	</Sidebar.Footer>
 {/if}

--- a/packages/map-next/src/lib/components/domain/initiatives/InitiativeProfile.svelte
+++ b/packages/map-next/src/lib/components/domain/initiatives/InitiativeProfile.svelte
@@ -8,11 +8,12 @@
 	import { Paragraph } from '$lib/components/typography';
 	import { EditorAccountInfo, EditorSaveBar, FormInput } from '$lib/components/forms';
 	import {
-		EntryContactForm,
+		EntryContactView,
 		IdentitySection,
 		DescriptionSection,
 		BadgesSection
 	} from '$lib/components/domain/entries';
+	import { authStore } from '$lib/stores/auth.svelte';
 	import { copyProfileLink } from '$lib/utils/share';
 	import { InitiativeGoalsSection } from './sections';
 	import * as m from '$lib/paraglide/messages.js';
@@ -98,7 +99,11 @@
 		hasUnsavedChanges: () => hasUnsavedChanges
 	});
 
+	// Feature 5: the contact CTA opens a dedicated drawer view (not an appended
+	// section). Sender fields prefill from the session but stay editable.
 	let showContactForm = $state(false);
+	const contactPrefillName = $derived(authStore.user?.name ?? '');
+	const contactPrefillEmail = $derived(authStore.user?.email ?? '');
 
 	async function handleSubmit() {
 		if (isSaving) {
@@ -161,109 +166,118 @@
 	);
 </script>
 
-<Sidebar.Header class="border-b">
-	<div class="flex items-start justify-between gap-2">
-		<div class="flex min-w-0 flex-1 items-start gap-3">
-			<div class="mt-1 shrink-0 text-muted-foreground">
-				<img class="size-9 object-contain" src={icon} alt={title} />
+{#if mode === 'read' && showContactForm && properties}
+	<EntryContactView
+		entryId={properties.id}
+		entryType="Initiative"
+		entryName={properties.name}
+		initialName={contactPrefillName}
+		initialEmail={contactPrefillEmail}
+		onBack={() => (showContactForm = false)}
+	/>
+{:else}
+	<Sidebar.Header class="border-b">
+		<div class="flex items-start justify-between gap-2">
+			<div class="flex min-w-0 flex-1 items-start gap-3">
+				<div class="mt-1 shrink-0 text-muted-foreground">
+					<img class="size-9 object-contain" src={icon} alt={title} />
+				</div>
+				<div class="flex min-w-0 flex-1 flex-col gap-1">
+					{#if mode === 'edit'}
+						<FormInput
+							id="entry-editor-name"
+							data-testid="editor-input-name"
+							label={m.editor_field_name()}
+							required
+							bind:value={$formData.name}
+							error={$errors.name}
+						/>
+					{:else}
+						<h2 class="text-lg leading-tight font-semibold text-foreground">{properties?.name}</h2>
+					{/if}
+				</div>
 			</div>
-			<div class="flex min-w-0 flex-1 flex-col gap-1">
+			<div class="flex shrink-0 items-center gap-1">
 				{#if mode === 'edit'}
-					<FormInput
-						id="entry-editor-name"
-						data-testid="editor-input-name"
-						label={m.editor_field_name()}
-						required
-						bind:value={$formData.name}
-						error={$errors.name}
-					/>
+					<AppButton
+						type="button"
+						variant="outline"
+						data-testid="entry-editor-cancel"
+						onclick={() => void handleCancel()}
+					>
+						{m.editor_cancel()}
+					</AppButton>
 				{:else}
-					<h2 class="text-lg leading-tight font-semibold text-foreground">{properties?.name}</h2>
+					{#if canEdit && onEdit}
+						<AppButton variant="outline" data-testid="entry-detail-edit" onclick={onEdit}>
+							{m.map_sidebar_action_edit()}
+						</AppButton>
+					{/if}
+					<IconButton
+						class="shrink-0"
+						data-testid="entry-detail-share"
+						label={m.entry_share_action()}
+						onclick={() => void handleShare()}
+					>
+						<LinkIcon />
+					</IconButton>
+					<IconButton
+						class="shrink-0"
+						data-testid="entry-detail-close"
+						label={m.map_token_feedback_dismiss()}
+						onclick={onClose}
+					>
+						<XIcon />
+					</IconButton>
 				{/if}
 			</div>
 		</div>
-		<div class="flex shrink-0 items-center gap-1">
-			{#if mode === 'edit'}
-				<AppButton
-					type="button"
-					variant="outline"
-					data-testid="entry-editor-cancel"
-					onclick={() => void handleCancel()}
-				>
-					{m.editor_cancel()}
-				</AppButton>
-			{:else}
-				{#if canEdit && onEdit}
-					<AppButton variant="outline" data-testid="entry-detail-edit" onclick={onEdit}>
-						{m.map_sidebar_action_edit()}
-					</AppButton>
-				{/if}
-				<IconButton
-					class="shrink-0"
-					data-testid="entry-detail-share"
-					label={m.entry_share_action()}
-					onclick={() => void handleShare()}
-				>
-					<LinkIcon />
-				</IconButton>
-				<IconButton
-					class="shrink-0"
-					data-testid="entry-detail-close"
-					label={m.map_token_feedback_dismiss()}
-					onclick={onClose}
-				>
-					<XIcon />
-				</IconButton>
-			{/if}
-		</div>
-	</div>
-</Sidebar.Header>
+	</Sidebar.Header>
 
-<Sidebar.Content class="overflow-y-auto">
-	{#if mode === 'edit'}
-		<form
-			class="flex flex-col gap-4 p-4 pb-24"
-			data-testid="entry-editor"
-			onsubmit={handleFormSubmit}
-		>
-			<Paragraph size="small">{m.user_form_required_fields()}</Paragraph>
-			<Paragraph size="small">{m.editor_initiative_intro()}</Paragraph>
+	<Sidebar.Content class="overflow-y-auto">
+		{#if mode === 'edit'}
+			<form
+				class="flex flex-col gap-4 p-4 pb-24"
+				data-testid="entry-editor"
+				onsubmit={handleFormSubmit}
+			>
+				<Paragraph size="small">{m.user_form_required_fields()}</Paragraph>
+				<Paragraph size="small">{m.editor_initiative_intro()}</Paragraph>
 
-			<IdentitySection mode="edit" {form} markerType="Initiative" />
-			<DescriptionSection mode="edit" {form} />
-			<EditorAccountInfo />
-			<InitiativeGoalsSection mode="edit" {form} {goals} />
-			<BadgesSection mode="edit" {form} {badges} idPrefix="initiative-badge" />
+				<IdentitySection mode="edit" {form} markerType="Initiative" />
+				<DescriptionSection mode="edit" {form} />
+				<EditorAccountInfo />
+				<InitiativeGoalsSection mode="edit" {form} {goals} />
+				<BadgesSection mode="edit" {form} {badges} idPrefix="initiative-badge" />
 
-			<EditorSaveBar {isSaving} {sectionErrors} onCancel={() => void handleCancel()} />
-		</form>
-	{:else}
-		<!-- `divide-y` draws separators only between rendered sections; empty
+				<EditorSaveBar {isSaving} {sectionErrors} onCancel={() => void handleCancel()} />
+			</form>
+		{:else}
+			<!-- `divide-y` draws separators only between rendered sections; empty
 		     sections render no element, so no stray dividers appear (F12.2). -->
-		<div
-			class="flex flex-col divide-y divide-border p-4 [&>*]:py-4 [&>*:first-child]:pt-0 [&>*:last-child]:pb-0"
-		>
-			<IdentitySection mode="read" {properties} {form} markerType="Initiative" />
-			<DescriptionSection mode="read" {properties} {form} />
-			<InitiativeGoalsSection mode="read" {properties} {form} />
-			<BadgesSection mode="read" {properties} {form} idPrefix="initiative-badge" />
+			<div
+				class="flex flex-col divide-y divide-border p-4 [&>*]:py-4 [&>*:first-child]:pt-0 [&>*:last-child]:pb-0"
+			>
+				<IdentitySection mode="read" {properties} {form} markerType="Initiative" />
+				<DescriptionSection mode="read" {properties} {form} />
+				<InitiativeGoalsSection mode="read" {properties} {form} />
+				<BadgesSection mode="read" {properties} {form} idPrefix="initiative-badge" />
+			</div>
+		{/if}
+	</Sidebar.Content>
 
-			{#if properties && showContactForm}
-				<EntryContactForm entryId={properties.id} entryType="Initiative" />
-			{/if}
-		</div>
+	<!-- Feature 5.3: the CTA is hidden on entries the current account owns
+	     (`canEdit`), who edit rather than contact themselves. -->
+	{#if mode === 'read' && properties && !canEdit}
+		<Sidebar.Footer class="border-t p-4">
+			<AppButton
+				type="button"
+				class="w-full"
+				data-testid="entry-contact-toggle"
+				onclick={() => (showContactForm = true)}
+			>
+				{m.entry_contact_button()}
+			</AppButton>
+		</Sidebar.Footer>
 	{/if}
-</Sidebar.Content>
-
-{#if mode === 'read' && properties && !showContactForm}
-	<Sidebar.Footer class="border-t p-4">
-		<AppButton
-			type="button"
-			class="w-full"
-			data-testid="entry-contact-toggle"
-			onclick={() => (showContactForm = true)}
-		>
-			{m.entry_contact_button()}
-		</AppButton>
-	</Sidebar.Footer>
 {/if}

--- a/packages/map-next/src/lib/components/domain/initiatives/InitiativeProfile.svelte
+++ b/packages/map-next/src/lib/components/domain/initiatives/InitiativeProfile.svelte
@@ -166,7 +166,10 @@
 	);
 </script>
 
-{#if mode === 'read' && showContactForm && properties}
+<!-- `!canEdit` also gates the view (not just the CTA): ownership resolves async
+     (myEntries load), so an owner can open contact before `canEdit` flips true —
+     re-checking here unmounts the view the moment ownership is known (F5.3). -->
+{#if mode === 'read' && showContactForm && properties && !canEdit}
 	<EntryContactView
 		entryId={properties.id}
 		entryType="Initiative"

--- a/specs/map-next-design-consistency/plan.md
+++ b/specs/map-next-design-consistency/plan.md
@@ -27,11 +27,11 @@ Status legend: [ ] todo · [~] in progress · [x] done
   - [ ] 4.2 Refactor edit mode to render the same `ProfileSection` sequence as read mode (same headings, same order), swapping only section bodies; move the name field into the Identity section and show the entry name as the header heading in both modes
   - [ ] 4.3 Reduce to exactly one Cancel and one Save control in edit mode (keep `EditorSaveBar`, drop the header Abbrechen) for farm, initiative, and depot editors
   - [ ] 4.4 Verify parity: toggling Bearbeiten keeps each section heading in the same position (± form-control height); no terminology differs between modes; run/extend the profile e2e
-- [ ] 5. Contact form as its own drawer view (depends on: none)
-  - [ ] 5.1 Add a `contact` drawer view to the profile flow (`MapSidebar.svelte` / profile components): footer CTA replaces drawer content with a contact view (entry name visible, back button returns to profile; decide and document top-vs-preserved scroll)
-  - [ ] 5.2 Prefill name/email from the authenticated session into `EntryContactForm`, fields remain editable
-  - [ ] 5.3 Hide the "Kontakt aufnehmen" CTA on entries owned by the current account
-  - [ ] 5.4 On successful send: sonner toast + return to the profile view; cover the flow with an e2e or component test
+- [x] 5. Contact form as its own drawer view (depends on: none)
+  - [x] 5.1 Add a `contact` drawer view to the profile flow (`MapSidebar.svelte` / profile components): footer CTA replaces drawer content with a contact view (entry name visible, back button returns to profile; decide and document top-vs-preserved scroll)
+  - [x] 5.2 Prefill name/email from the authenticated session into `EntryContactForm`, fields remain editable
+  - [x] 5.3 Hide the "Kontakt aufnehmen" CTA on entries owned by the current account
+  - [x] 5.4 On successful send: sonner toast + return to the profile view; cover the flow with an e2e or component test
 - [ ] 6. Collapsible depot list on farm profiles (depends on: 1)
   - [ ] 6.1 Rework `FarmDepotsSection.svelte` rows to a compact one-line format (name + place, details on click) and show the depot count in the section heading
   - [ ] 6.2 Cap the initial list at 5 with an "Alle N anzeigen" / collapse toggle (local state, new paraglide messages in all locales)


### PR DESCRIPTION
Implements Feature 5 of the map-next design-consistency pass: the "Kontakt aufnehmen" CTA now opens a dedicated contact drawer view (entry name + back button) instead of appending the form inside the profile, and the CTA is hidden on entries the current account owns. For a logged-in user the sender name/email prefill from the session and stay editable; a successful send shows a sonner toast and returns to the profile (scrolled to top). Adds an `entry_contact_back` label across all four locales and covers the flow with a new `contact-drawer` e2e plus updated `contact-token-feedback` assertions.

Verification: `npm run check` (0 errors), eslint/prettier clean, and `playwright test contact-drawer contact-token-feedback detail-profile-polish` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)