### PR TITLE
docs(specs): admin package audit spec and plan

### DIFF
--- a/specs/admin-package-improvements/plan.md
+++ b/specs/admin-package-improvements/plan.md
@@ -1,0 +1,82 @@
+# Implementation Plan: Admin Package Improvements
+
+Spec: specs/admin-package-improvements/spec.md
+
+Status legend: [ ] todo · [~] in progress · [x] done
+
+- [ ] 1. Fix dead permission checks in email lists (depends on: none)
+  - [ ] 1.1 Replace the `const { permissions } = props` pattern with the `usePermissions()` hook in `EmailCampaignsList` and `EmailMessagesList` (`src/resources/emailCampaigns.jsx`, `src/resources/emailMessages.jsx`)
+  - [ ] 1.2 Verify against a local API: superadmin sees working Delete buttons in both lists, plain admin does not; `grep` confirms no list component reads `permissions` from props
+
+- [ ] 2. Fix sidebar menu collapse styling in AppMenu (depends on: none)
+  - [ ] 2.1 In `src/components/AppMenu.jsx`, read the sidebar state via react-admin's `useSidebarState()` and remove the undefined-`open` classnames logic and the `lodash` import
+  - [ ] 2.2 Replace `makeStyles`/`classnames` in `AppMenu.jsx` with `sx`/`styled` (drop the `classnames` import if no longer needed anywhere)
+  - [ ] 2.3 Verify the sidebar toggle switches the menu between 240px (open) and 55px (closed) width
+
+- [ ] 3. Fix role-conditional section and role id handling in the user form (depends on: none)
+  - [ ] 3.1 Add named role id constants (`ROLE_USER`, `ROLE_ADMIN`, `ROLE_SUPERADMIN`) to `src/lib/enumerations.js`
+  - [ ] 3.2 In `src/components/UserFormUserTab.jsx`, guard `roles` being undefined and fix the integer-vs-string comparison (normalize with `.map(String)` or compare numerically); first verify the actual runtime type with a real record
+  - [ ] 3.3 Replace the hardcoded `'roles.id': '1'/'2'/'3'` values in `src/resources/users.jsx` quick filters with the new constants
+  - [ ] 3.4 Verify: editing an admin/superadmin user shows the adminOrigins select and "Receive Admin Emails" toggle, a plain user hides them, and toggling roles in the form shows/hides the section without a crash
+
+- [ ] 4. Fix UsersEdit transform and make transforms non-mutating (depends on: none)
+  - [ ] 4.1 In `src/resources/users.jsx`, fix the `UsersEdit` transform to strip `roles` and `adminOrigins` (not `origins`) via rest/spread instead of `delete`
+  - [ ] 4.2 In `src/resources/emailCampaigns.jsx`, make the `EmailCampaignsCreate` transform (`testEmailUser` removal) non-mutating
+
+- [ ] 5. Robust auth provider: logout on 401, safe getPermissions, own module (depends on: none)
+  - [ ] 5.1 Create `src/authProvider.js`: move the provider out of `App.jsx`, implement `checkError` rejecting on 401/403 responses, and guard `getPermissions` against a missing/undecodable JWT (clean rejection, no synchronous throw)
+  - [ ] 5.2 Move `useStatus` from `App.jsx` to `src/hooks/useStatus.js` and update imports in `jobs.jsx`, `emailCampaigns.jsx`, `emailMessages.jsx`; confirm no module imports from `../App` anymore
+  - [ ] 5.3 Verify: with a garbage `feathers-jwt` in localStorage, opening any list redirects to login; with no token, `getPermissions` rejects without an uncaught exception
+
+- [ ] 6. Single, cached, typed status/feature-flag handling (depends on: 5)
+  - [ ] 6.1 Rework `src/hooks/useStatus.js`: fetch `/status` once per session (cached), normalize feature flags to booleans, treat fetch failure as all-features-disabled without unhandled rejections
+  - [ ] 6.2 Update consumers (`jobs.jsx`, `emailCampaigns.jsx`, `emailMessages.jsx`) to test boolean flags, and fix the `hasCreate` flash in `EmailCampaignsList` while status is loading
+  - [ ] 6.3 Verify in devtools: at most one `/status` request when navigating between Jobs, Email Campaigns, and Email Messages; lists render with the API stopped
+
+- [ ] 7. Remove dead code, CRA leftovers, and dependency hygiene (depends on: 2)
+  - [ ] 7.1 Delete `src/components/DocsPage.jsx`, `src/components/EntriesChart.jsx`, `src/App.css`, and `src/logo.svg` (confirm unused first); delete the passthrough `src/components/Pagination.jsx` or give it real defaults, updating all imports
+  - [ ] 7.2 Clean `package.json`: move `@vitejs/plugin-react-swc` to devDependencies, remove `@vitejs/plugin-react-refresh`, remove `recharts`/`date-fns`/`prop-types`/`classnames` if unused after 7.1, confirm `lodash` is neither used nor declared
+  - [ ] 7.3 Clean `index.html` (stale CRA comments, dead `logo192.png` apple-touch-icon) and fix `public/manifest.json` icon references
+  - [ ] 7.4 Replace `App.test.jsx`/`setupTests.js` with a vitest setup and one real smoke test (render the login page); wire `npm test` to vitest
+  - [ ] 7.5 Run `npm run build` and `npx depcheck`; fix any leftover references or unused/undeclared dependencies
+
+- [ ] 8. Deduplicate lists/forms and set input defaults at the theme level (depends on: 2)
+  - [ ] 8.1 Add `components.defaultProps` to `src/theme.js` so text/select/number/boolean/date inputs default to `variant='standard'` and no margin; strip the now-redundant `variant`/`margin` props across `src/resources/` and `src/components/` (target: zero occurrences)
+  - [ ] 8.2 Extract `FormToolbar` (Cancel + Save, unified `variant='filled'` Cancel), `AdminFormSection` (active/ownerships/createdAt/updatedAt column), and `AddressFormSection` (address/housenumber/postalcode/city/state/country rows) and use them in `FarmForm`, `DepotForm`, `InitiativeForm`
+  - [ ] 8.3 Extract the shared farms/depots/initiatives datagrid (id, name, city, state, country, createdAt, updatedAt, active, edit/delete) into a common component used by all three lists
+  - [ ] 8.4 Merge `UserCountCard` and `EntryCountCard` into one `StatCard` (add `img` alt text, remove the phantom `classes.card` reference)
+  - [ ] 8.5 Replace `TwoElementRow`'s double-margin flexbox with MUI `Stack`/`Grid` spacing (keep the `ratio` prop behavior)
+  - [ ] 8.6 Migrate the remaining `makeStyles` usages (`Dashboard.jsx`, `AppBar.jsx`, `StatCard`) to `sx`/`styled`; remove `@mui/styles` from `package.json` and from the `.ncurc.js` reject list
+  - [ ] 8.7 Visual spot-check all six edit forms and all list filter bars against the pre-change rendering
+
+- [ ] 9. Idiomatic, consistent filters (depends on: 3, 8)
+  - [ ] 9.1 Convert every list from the legacy `<Filter>` wrapper element to react-admin 5 `filters={[...]}` input arrays (farms, depots, initiatives, users, emailMessages)
+  - [ ] 9.2 Try replacing the forked `src/components/FilterLiveSearch.jsx` with react-admin's exported `FilterLiveSearch`; if a concrete gap remains after Feature 8's theme defaults, keep the fork with an in-code comment documenting the gap
+  - [ ] 9.3 Extract shared `CountryFilterList` (DEU/CHE/AUT) and `ActiveFilterList` (Yes/No) sidebar components and use them in the farms/depots/initiatives sidebars
+  - [ ] 9.4 Unify badge filter value types to numbers in `farms.jsx` (toolbar select and sidebar items), centralize badge ids/labels (constants or loaded from `admin/badges`), and fix `toggleBadgeFilter` mutating its `filters` argument
+  - [ ] 9.5 In `users.jsx`, render the static filters immediately and gate only the origin `SelectInput` on the origins fetch
+  - [ ] 9.6 Verify: toolbar and sidebar badge filters stay in sync (same value type), users list shows its filter toolbar instantly, country/active sections come from the shared components
+
+- [ ] 10. Fix admin-role user edit end to end (API field-permission mismatch) (depends on: none)
+  - [ ] 10.1 Reproduce against a local API: as a non-superadmin admin, toggle "Receive Admin Emails" on a user and confirm the PATCH returns 403 due to the snake_case `admin_email_notifications` field allowlist
+  - [ ] 10.2 Fix the field list in `packages/api/src/permissions.js` (admin scope for `admin/users:update`) to match the camelCase key the client sends
+  - [ ] 10.3 Add an API test: admin can patch `name`/`email`/`phone`/`adminEmailNotifications`, still gets 403 when patching `roles`
+
+- [ ] 11. Dashboard robustness (depends on: none)
+  - [ ] 11.1 Rework `src/components/Dashboard.jsx` data fetching: handle the response shape explicitly (`.data` or raw array), use `null` initial state with loading placeholders, catch errors and surface them via `useNotify`, and skip fetching when the user lacks the admin role
+  - [ ] 11.2 Make `findCountInStats` return a fallback (0/`'–'`) for unknown resources/states instead of throwing
+  - [ ] 11.3 Verify: dashboard counts match the filtered lists; with the API stopped, an error notification appears and no unhandled rejection is logged
+
+- [ ] 12. Jobs list hardening and RPC-button cleanup (depends on: none)
+  - [ ] 12.1 In `src/resources/jobs.jsx`, wrap the cron explanation in a guarded helper (try/catch, fall back to the raw string) and guard `useRecordContext()` destructures there plus in `bounces.jsx` (`EditUserButton`) and `UserForm.jsx` (`EntryEditButton`)
+  - [ ] 12.2 Fix the jobs Datagrid sorting: remove the invalid `sort={false}` prop and mark each column `sortable={false}`
+  - [ ] 12.3 In `SendCampaignButton.jsx`, `UserStateChangeButton.jsx`, and the jobs `RunButton`: remove the `useEffect(() => refresh(), [isLoading])` pattern, use `onSuccess`/`onError` callbacks with `useNotify` for error surfacing, and refresh exactly once on success
+  - [ ] 12.4 Verify: a job row with an invalid cron string renders instead of crashing (unit test the helper), jobs column headers are not sortable, failed send/run/state-change calls show an error notification
+
+- [ ] 13. UI consistency & theming polish (depends on: 2)
+  - [ ] 13.1 Move hardcoded colors into the theme: `#266050` in `AppBar.jsx` → `palette.secondary.main`, link color and `#fffcf9` card background in `EmailCampaignForm.jsx` → palette values; delete the commented-out "API Docs" block in `AppBar.jsx`
+  - [ ] 13.2 Give each resource a distinct MUI icon via the `<Resource icon>` prop in `App.jsx` and use them in `AppMenu.jsx` instead of the shared `ViewList` icon
+  - [ ] 13.3 Label the login identifier field "Email" (custom login page or i18n message override)
+  - [ ] 13.4 Switch list `DeleteButton`s (farms, depots, initiatives, users, email lists) to `mutationMode='pessimistic'` so destructive deletes require confirmation
+  - [ ] 13.5 Normalize label casing across datagrid headers and sidebar quick-filter labels (e.g. `id` → `Id`/`ID`, consistent `Verified` naming)
+  - [ ] 13.6 Rename the `FarmsFilterSidebar` component inside `src/components/FilterSidebar.jsx` to `FilterSidebar`, and move the email-messages pagination limitation comment onto the Pagination props in `emailMessages.jsx`

--- a/specs/admin-package-improvements/spec.md
+++ b/specs/admin-package-improvements/spec.md
@@ -1,0 +1,340 @@
+# Spec: Admin Package Improvements
+
+## Problem Statement
+
+`packages/admin` is the react-admin based administration UI for Ernte Teilen. It was
+bootstrapped with Create React App years ago, later moved to Vite, and upgraded to
+react-admin 5 — but much of the code still follows react-admin 3/CRA-era patterns.
+A code audit (2026-07-08) found confirmed bugs (dead permission checks, a broken
+sidebar-collapse class, a wrong transform key), security/auth hygiene gaps
+(`checkError` never logs out on 401), heavy duplication (167 repetitions of
+`variant='standard'`, three nearly identical entry forms/lists/filter sidebars),
+dead CRA leftovers, and UI inconsistencies.
+
+This spec captures the audit findings as implementable features so the admin UI
+becomes correct, consistent, and cheap to maintain. The API (`packages/api`) enforces
+authorization centrally via a permission matrix (`src/permissions.js` + `authorize`
+hook), so all client-side role gating is cosmetic UX — this spec does not change the
+security model, it fixes the client's correctness and hygiene around it.
+
+Verified environment facts (checked against installed packages, do not re-litigate):
+
+- react-admin 5.14.7. `Resource` renders `list`/`edit` elements with **no props**
+  (`ra-core/dist/core/Resource.js`), so `props.permissions` inside list components is
+  always `undefined`.
+- The dashboard **does** receive a `permissions` prop (rendered via `WithPermissions`).
+- The legacy function-style `ra-data-feathers` provider is still supported via
+  `convertLegacyDataProvider`.
+- `dataProvider.getList` returns `{ data, total }`; the Dashboard's `stats.find(...)`
+  only works by accident because `admin/stats` returns a raw array that
+  `ra-data-feathers` mutates in place (adds `.data`/`.total` onto the array).
+- API `admin` role may PATCH `admin/users` fields `['name', 'email', 'phone',
+'admin_email_notifications']` (note: snake_case, while the client sends camelCase
+  `adminEmailNotifications` — see Feature 10).
+
+## Features
+
+1. **Fix dead permission checks in email lists**
+   - Description: `EmailCampaignsList` and `EmailMessagesList` read
+     `const { permissions } = props`, which is always `undefined` in react-admin 5,
+     so their `DeleteButton`s never render even for superadmins. Use the
+     `usePermissions()` hook like the other lists do.
+   - Acceptance criteria:
+     - Logged in as superadmin, the Email Campaigns and Email Messages datagrids show
+       a working Delete button per row.
+     - Logged in as a plain admin, no Delete button is shown in these lists.
+     - No list component reads `permissions` from props anywhere in the package.
+
+2. **Fix sidebar menu collapse styling in `AppMenu`**
+   - Description: `AppMenu.jsx` computes `{ [classes.open]: open, [classes.closed]: !open }`
+     but `open` is never defined — it resolves to the global `window.open` function
+     (always truthy), so the menu is permanently styled "open" and the collapsed state
+     never applies its narrow width. Use react-admin's `useSidebarState()` for the
+     actual state. While here, drop the `lodash` import (`_.get` over two local
+     constants; lodash is not even declared in `package.json` — it only resolves via
+     hoisting) and migrate the `makeStyles` usage to `sx`/`styled` (see Feature 8).
+   - Acceptance criteria:
+     - Toggling the sidebar (hamburger) visibly switches the menu between
+       `MENU_WIDTH` (240px) and `CLOSED_MENU_WIDTH` (55px).
+     - `lodash` is no longer imported anywhere in `packages/admin/src`.
+     - No reference to an undefined `open` variable remains (verify with lint).
+
+3. **Fix role-conditional section and role id handling in the user form**
+   - Description: `UserFormUserTab.jsx` shows the admin-origins/notifications section
+     when `roles.includes('2') || roles.includes('3')`. The API maps the `roles`
+     relation to an array of **integer** ids (`mapResultRelationsToIds`), so the
+     string comparison likely never matches and the section never renders for
+     admin/superadmin users (verify at implementation with a real record; fix the
+     comparison either way, e.g. compare loosely or normalize with `.map(String)`).
+     `roles` can also be `undefined` before the record loads → guard it. Role ids
+     `1/2/3` are magic numbers duplicated here and in `users.jsx` (roles quick
+     filter) — centralize them in `src/lib/enumerations.js` with named constants
+     (`ROLE_USER = 1`, `ROLE_ADMIN = 2`, `ROLE_SUPERADMIN = 3`).
+   - Acceptance criteria:
+     - Editing a user who has the admin or superadmin role shows the "adminOrigins"
+       select and "Receive Admin Emails" toggle; editing a plain user hides them.
+     - Toggling roles in the form immediately shows/hides that section without a crash.
+     - Role ids appear exactly once in the codebase (enumerations module); `users.jsx`
+       and `UserFormUserTab.jsx` consume the constants.
+
+4. **Fix `UsersEdit` transform and make transforms non-mutating**
+   - Description: `UsersEdit`'s transform deletes `data.roles` and `data.origins` for
+     non-superadmins, but the form field is `adminOrigins` — `data.origins` doesn't
+     exist, so `adminOrigins` would be submitted if it ever changed. Delete the right
+     key. Also return a new object instead of mutating the react-admin `data`
+     argument (same for the `EmailCampaignsCreate` transform which deletes
+     `testEmailUser`).
+   - Acceptance criteria:
+     - The transform strips `roles` and `adminOrigins` (not `origins`) when the editor
+       lacks the superadmin role.
+     - Transforms in `users.jsx` and `emailCampaigns.jsx` build new objects (rest/spread)
+       rather than `delete` on the input.
+
+5. **Robust auth provider: logout on 401, safe `getPermissions`, own module**
+   - Description: the `authProvider` in `App.jsx` has `checkError: () => Promise.resolve()`,
+     so an expired/invalid JWT never redirects to login — every request just keeps
+     failing with error notifications. Implement the react-admin contract: reject on
+     401/403 responses so the user is logged out and redirected. `getPermissions`
+     calls `jwtDecode(localStorage.getItem('feathers-jwt'))` unguarded — a missing
+     token throws synchronously (jwt-decode v4 throws on non-string), and the
+     `roles ? ... : Promise.reject(...)` check after `.map()` is unreachable. Guard
+     missing/undecodable tokens by rejecting cleanly. Move `authProvider` (and
+     `useStatus`, see Feature 6) out of `App.jsx` into dedicated modules
+     (`src/authProvider.js`, `src/hooks/useStatus.js`) — resources currently import
+     `useStatus` from `../App` while `App` imports the resources (circular import).
+   - Acceptance criteria:
+     - With an expired/garbage `feathers-jwt` in localStorage, opening any list
+       redirects to the login screen instead of showing endless failing requests.
+     - With no token present, `getPermissions` rejects (no uncaught synchronous throw;
+       verify via unit test or manual localStorage clear while on a page).
+     - `App.jsx` no longer defines `authProvider` or `useStatus`; no module imports
+       from `../App`.
+
+6. **Single, cached, typed status/feature-flag handling**
+   - Description: `useStatus()` fires a fresh unauthenticated-error-prone
+     `status.find()` on every mount of every component that uses it (jobs list, both
+     email lists), has no error handling, and every consumer string-compares
+     `feature === 'true'`. Fetch the status once (react-query via react-admin's
+     `useQuery`-style hooks or module-level cache), normalize flags to booleans in one
+     place, and handle fetch failure (treat features as disabled). Also fix the
+     UX flash in `EmailCampaignsList` where `hasCreate` is false during the fetch.
+   - Acceptance criteria:
+     - Navigating between Jobs / Email Campaigns / Email Messages triggers at most one
+       `/status` request per session (verify in devtools network tab).
+     - Consumers test booleans (`features.emailCampaigns`), not `=== 'true'`.
+     - If `/status` fails, the lists still render (feature-gated buttons hidden) and no
+       unhandled promise rejection appears in the console.
+
+7. **Remove dead code, CRA leftovers, and dependency hygiene**
+   - Description: delete `src/components/DocsPage.jsx` (unreferenced; uses webpack
+     `!babel-loader!` import syntax that cannot work under Vite and points to a
+     non-existent `content/apidocs.mdx`), `src/components/EntriesChart.jsx`
+     (unreferenced; ~70 lines commented out) — recharts and date-fns become removable
+     dependencies if nothing else uses them, `src/App.css` (unimported CRA logo-spinner
+     styles), `src/logo.svg` if unused, and `src/components/Pagination.jsx` (pure
+     passthrough — either delete and use `<Pagination>` from react-admin directly, or
+     give it real defaults like `rowsPerPageOptions`). Replace `App.test.jsx` (asserts
+     a CRA "learn react link" that doesn't exist and never runs — the `test` script is
+     `echo 'noop'`) with a minimal real smoke test wired to `vitest` (deps are already
+     present via testing-library), or delete it together with `setupTests.js` if the
+     team decides against tests. Clean `index.html` (stale CRA comments, dead
+     `logo192.png` apple-touch-icon reference) and `public/manifest.json` icon
+     references. Package.json: move `@vitejs/plugin-react-swc` to devDependencies,
+     remove obsolete `@vitejs/plugin-react-refresh`, remove `prop-types`/`classnames`
+     if unused after Feature 2, declare or (preferably) drop `lodash`.
+   - Acceptance criteria:
+     - `npm run build` succeeds after removals; `grep` finds no references to the
+       deleted files.
+     - `npm test` either runs a passing vitest suite or the script and test scaffolding
+       are removed entirely (team choice; default: add vitest smoke test that renders
+       the login page).
+     - No dependency in `package.json` is unused, and nothing imported is undeclared
+       (verify with `npx depcheck` or equivalent).
+
+8. **Deduplicate lists/forms and set input defaults at the theme level**
+   - Description: `variant='standard'` appears 167× and `margin='none'` 159× — set
+     these once in `theme.js` via MUI/react-admin `components.defaultProps`
+     (e.g. `MuiTextField`, `RaSelectInput`, etc.) and strip the per-input props.
+     Extract the shared structures:
+     - Farms/Depots/Initiatives lists are identical except columns/forms → shared
+       datagrid column set or a common `EntryList` wrapper.
+     - The three entry forms repeat the same address block (`address`/`housenumber`/
+       `postalcode`/`city`/`state`/`country`), the same right-hand "Admin" column
+       (`active`, `ownerships`, `createdAt`, `updatedAt`) and the same Cancel/Save
+       toolbar → extract `AddressFormSection`, `AdminFormSection`, `FormToolbar`
+       (one component; note today `FarmForm`'s Cancel lacks the `variant='filled'`
+       the others have — unify).
+     - `UserCountCard` and `EntryCountCard` are near-identical → one `StatCard`
+       (fixes the missing `img alt` too). `classes.card` referenced in both does not
+       exist in their `useStyles` — remove.
+     - `TwoElementRow` applies `marginRight` to both columns (asymmetric trailing
+       margin) → use MUI `Stack`/`Grid` spacing.
+     - Migrate remaining `makeStyles` (`@mui/styles`, deprecated legacy engine that
+       currently blocks MUI upgrades — see `.ncurc.js` reject list) to `sx`/`styled`,
+       then remove `@mui/styles` from dependencies and from the `.ncurc.js` rejects.
+   - Acceptance criteria:
+     - `grep -c "variant='standard'"` over `src` returns 0 (theme default covers it);
+       forms and filters render visually unchanged (spot-check farms edit, user edit,
+       users list filters).
+     - `@mui/styles` and `makeStyles` are gone from source and `package.json`.
+     - Farms/Depots/Initiatives forms share the address, admin-column, and toolbar
+       components; total package LOC drops measurably (expect >400 lines).
+
+9. **Idiomatic, consistent filters**
+   - Description: all lists use the legacy `<Filter>` wrapper element; react-admin 5's
+     idiom is passing an **array of inputs** as `filters`. Convert, and while doing so:
+     - Replace the forked `src/components/FilterLiveSearch.jsx` (copied react-admin
+       internals) with react-admin's exported `FilterLiveSearch` if it supports the
+       needed props after Feature 8's theme defaults; keep the fork only if a concrete
+       gap is documented in-code.
+     - Dedupe the country (`DEU`/`CHE`/`AUT`) and Active Yes/No `FilterList` blocks
+       repeated across farms/depots/initiatives sidebars into shared components.
+     - Unify badge filter value types: the farms toolbar filter uses string ids
+       (`'1'`/`'2'`) while the sidebar uses numbers (`1`/`2`), so the two UIs disagree
+       about whether the same filter is active. Pick one type (number) and use the
+       badge-name constants from Feature 3's enumerations approach; badge ids/names
+       (`1` = Netzwerk solidarische Landwirtschaft e.V., `2` = FRACP) are currently
+       hardcoded in two shapes in `farms.jsx` — ideally load badge choices from
+       `admin/badges` like the forms do.
+     - `users.jsx` `UserFilter` renders `null` until origins load, hiding _all_
+       filters and the filter button; render the static filters immediately and only
+       gate the origin select.
+     - Fix `toggleBadgeFilter` in `farms.jsx` mutating the `filters` object it receives.
+   - Acceptance criteria:
+     - No `<Filter>` element usage remains; all lists pass `filters={[...]}` arrays.
+     - Selecting "Member" of a badge via the toolbar filter shows the sidebar item as
+       selected and vice versa (same value type end to end).
+     - Users list shows its filter toolbar instantly on first load (origins select may
+       appear when loaded).
+     - Country/Active sidebar sections are rendered by shared components.
+
+10. **Fix admin-role user edit end to end (client + API field-permission mismatch)**
+    - Description: the API allows the `admin` role to patch
+      `admin_email_notifications` (snake_case) on `admin/users`, but the client sends
+      `adminEmailNotifications` (camelCase) — so a plain admin toggling "Receive Admin
+      Emails" gets a 403 `Forbidden` from the `authorize` hook's field check
+      (`packages/api/src/permissions.js`, admin scope). Verify against a running API
+      and fix the field list server-side (camelCase, matching what Objection receives
+      in `ctx.data`) or map client-side — server fix preferred; it's a one-word change.
+    - Acceptance criteria:
+      - Logged in as a non-superadmin admin, toggling "Receive Admin Emails" on a user
+        and saving succeeds (no 403) and persists after reload.
+      - Patching a forbidden field (e.g. `roles`) as plain admin still returns 403
+        (regression check, covered by an API test).
+
+11. **Dashboard robustness**
+    - Description: `Dashboard.jsx` treats `dataProvider.getList('admin/stats', {})`
+      as an array (works only by accident, see verified facts), initializes numeric
+      counts with `useState([])`, has no error handling (a failed fetch is an
+      unhandled rejection and the cards silently stay empty), and `findCountInStats`
+      throws if a resource is missing. Rework: call the stats service once, read
+      `.data`, type-sensible initial state (`null` → show loading/placeholder), catch
+      errors and notify (`useNotify`), and guard missing resources/states. Keep the
+      accidental-array behavior working until the API's stats service is (optionally)
+      changed to return a paginated shape — do not require an API change here.
+    - Acceptance criteria:
+      - Dashboard renders correct counts for entries and user states (compare with the
+        respective filtered lists).
+      - With the API stopped, the dashboard shows an error notification and empty-state
+        placeholders instead of a console unhandled-rejection.
+      - `findCountInStats` returns a fallback (0/`'–'`) for unknown resources/states
+        instead of throwing.
+
+12. **Jobs list hardening and RPC-button cleanup**
+    - Description: in `jobs.jsx`, `CronExplanation` calls `cronstrue.toString(cron)`
+      unguarded — one malformed cron string in the DB crashes the whole list; wrap in
+      try/catch and fall back to the raw string. `useRecordContext(props)` can return
+      `undefined` — guard destructuring (also in `bounces.jsx` `EditUserButton` and
+      `UserForm`'s `EntryEditButton`). `Datagrid sort={false}` is not a react-admin
+      prop (columns must be `sortable={false}` individually, as `bounces.jsx` does) —
+      fix so clicking headers doesn't issue sort queries the custom jobs service
+      ignores. In `SendCampaignButton` and `UserStateChangeButton`, remove the
+      `useEffect(() => refresh(), [isLoading])` pattern (fires a spurious refresh on
+      mount and duplicates the explicit `refresh()` in the confirm handlers); rely on
+      `useUpdate`/`useCreate` callbacks (`onSuccess`) plus a single refresh, and
+      surface errors via `useNotify` (currently a failed job-run/campaign-send/state
+      change shows a success-looking silence).
+    - Acceptance criteria:
+      - A job row with an invalid cron string renders (raw string shown) instead of
+        crashing the list (unit-testable on the extracted explanation helper).
+      - Job list column headers are not clickable for sorting.
+      - Failed send-campaign / run-job / activate-deactivate calls show an error
+        notification; successful ones refresh the view exactly once.
+
+13. **UI consistency & theming polish**
+    - Description: assorted visual/UX inconsistencies:
+      - Hardcoded colors: `#266050` in `AppBar.jsx` (duplicates `theme.palette.secondary.main`),
+        link color `#266050` and card background `#fffcf9` in `EmailCampaignForm.jsx` —
+        use theme palette; delete the commented-out "API Docs" link block in `AppBar`.
+      - Every menu entry uses the same `ViewList` icon — pick distinct MUI icons per
+        resource (farms/depots/initiatives/users/bounces/etc.) and pass them to the
+        `<Resource icon>` prop so react-admin uses them consistently.
+      - Login form asks for "Username" but expects an email — provide a custom login
+        page or i18n override labeling it "Email".
+      - `DeleteButton`s in lists are undoable by default; for destructive admin ops on
+        real user data prefer `mutationMode='pessimistic'` with confirm dialog
+        (consistent with the Confirm dialogs used for campaign send / user deactivate).
+      - Datagrid header casing is inconsistent (`Verified` label vs auto-generated
+        `Is verified` elsewhere; sidebar quick-filter labels are lowercase `id`,
+        `name`, …) — normalize casing on labels.
+      - `FilterSidebar.jsx`'s component is named `FarmsFilterSidebar` though it is
+        generic — rename to `FilterSidebar`; replace magic `mt: 8` with a documented
+        constant if still needed after testing.
+      - Email messages list: `rowsPerPageOptions={[5, 10]}` is a workaround for an API
+        reference-batching limit (see in-code comment) — keep, but move the comment to
+        the Pagination props so it survives refactors.
+    - Acceptance criteria:
+      - `grep -rn "#266050\|#fffcf9" src` returns only `theme.js` (or nothing).
+      - Each menu entry/resource shows a distinct icon in the sidebar.
+      - Login screen labels the identifier field "Email".
+      - Deleting a farm/depot/initiative/user asks for confirmation before issuing the
+        request (no optimistic delete), and list labels use consistent casing.
+
+## Technical Solution
+
+- Architecture: pure refactor/bugfix of the existing react-admin 5 + Vite SPA. No new
+  routes or services. One deliberate cross-package touch: Feature 10's one-line
+  permission-field fix in `packages/api/src/permissions.js` plus an API test.
+- Technologies: keep react-admin 5.x, MUI 6, Vite 7, `ra-data-feathers` +
+  `feathers-client` v2 (replacing the legacy feathers client is explicitly out of
+  scope). Add `vitest` as the test runner (Feature 7) reusing the existing
+  testing-library devDependencies.
+- Key decisions:
+  - Client-side role gating remains cosmetic; the API permission matrix is the
+    security boundary (verified: `authorize` hook + `permissions.js` cover all
+    `/admin/*` services with scope, condition, and field checks).
+  - Theme-level `defaultProps` is the mechanism to kill the `variant`/`margin` prop
+    noise, rather than a custom wrapped-input component library.
+  - Enumerations (role ids, badge ids, user states) live in `src/lib/enumerations.js`
+    as the single source for magic ids the API exposes as integers.
+  - Ordering: Features 1–5 are independent bugfixes and can be implemented in any
+    order; Feature 8 (theme defaults) should land before Feature 9 (filters) to avoid
+    churn; Feature 7 (dead code) early to shrink the surface for the rest.
+
+## Out of Scope
+
+- Replacing `feathers-client` v2 / `ra-data-feathers` with `@feathersjs/client` v5 or
+  a custom data provider (large, risky; the legacy provider is still supported by
+  react-admin 5 via `convertLegacyDataProvider`).
+- Adding create views for farms/depots/initiatives/users (entries are created through
+  the map application; admin only edits).
+- i18n / full German-English translation cleanup of labels beyond the login field.
+- Moving the JWT out of localStorage or other auth-architecture changes (the committed
+  JWT secret rotation is a separate ops task, tracked outside any PR).
+- API stats service reshaping to a paginated response (Feature 11 must work without it).
+- Any changes to `packages/map` (legacy, being retired) or `packages/map-next`.
+
+## Additional Notes
+
+- Verify-at-implementation items (called out inline above): the integer-vs-string
+  `roles` comparison in Feature 3, the camelCase/snake_case 403 in Feature 10, and
+  whether react-admin's built-in `FilterLiveSearch` can replace the fork in Feature 9.
+- There is no CI test coverage for this package today (`test` script is a noop), so
+  every feature's acceptance relies on `npm run build` plus manual verification
+  against a locally running API; Feature 7 introduces the first real test entry point.
+- `.ncurc.js` currently rejects all `@mui/*` upgrades because of the deprecated
+  `@mui/styles` engine; Feature 8 removes that blocker — consider a follow-up
+  dependency-update pass afterwards.
+- Risk note: Feature 8's theme `defaultProps` change touches every input's visual
+  rendering; do a side-by-side visual pass of all six edit forms and all list filter
+  bars before merging.

--- a/specs/map-next-parity-ux/plan.md
+++ b/specs/map-next-parity-ux/plan.md
@@ -3,56 +3,57 @@
 Spec: specs/map-next-parity-ux/spec.md
 
 Status legend: [ ] todo · [~] in progress · [x] done
+Model legend: recommended implementer model per feature, by complexity/risk — Claude Sonnet (well-scoped, pattern-following) · Claude Opus (multi-component, stateful/integration complexity) · Claude Fable (architectural or destructive/data-integrity risk)
 
-- [x] 1. Geocoder address field in editors (depends on: none)
+- [x] 1. Geocoder address field in editors (depends on: none · model: Claude Opus)
   - [x] 1.1 Build `forms/GeocoderField.svelte` (semantic layer, on `InputGroup`): 300 ms debounced autocomplete (min 2 chars) against `getAutocompleteSuggestions({ withEntries: false })` + `geocodeLocationId()` from `$lib/api/discovery.ts`; selection writes address/street/housenumber/city/state/country/postalcode/lat/lon into the bound form model; clearing the input clears all address fields; existing address renders as "address, city" and an untouched field keeps stored values. Add a Storybook story.
   - [x] 1.2 Build a map preview component: tiny non-interactive MapLibre instance at fixed zoom ~14 (≤ app max zoom 15), reusing `map-style.ts` tokens, showing the correct entry-type marker once coordinates exist.
   - [x] 1.3 Replace `AddressFields.svelte` usage in `EntryEditor.svelte` and `DepotEditor.svelte` with GeocoderField + preview; keep address fields in the superforms schema but render no inputs; add "enter and select an address" validation (typed-but-unselected text fails) with translated messages in all four locales + `validations.json`.
   - [x] 1.4 Tests: unit tests for the selection/clear/untouched model behavior; update editor e2e tests to drive the geocoder flow in farm, initiative, and depot editors.
 
-- [x] 2. Farm and initiative deletion (depends on: 4)
+- [x] 2. Farm and initiative deletion (depends on: 4 · model: Claude Fable)
   - [x] 2.1 Verify actual API delete behavior for a farm with depots against the new FK constraints in packages/api (cascade vs restrict vs detach, own vs foreign-owned depots); record the result in the spec's Additional Notes and fix API behavior if it violates the "never delete foreign-owned depots" rule.
   - [x] 2.2 Add farm/initiative `DELETE` functions to `$lib/api/entry-mutations.ts` (depot delete as reference).
   - [x] 2.3 Implement `handleDeleteEntry` in `MapSidebar.svelte` / `EntryRowActions.svelte`: `confirmDialog` naming the entry, depot-consequence copy per 2.1, success toast, my-entries store refresh, map entry removal without reload, navigate back to my-entries; translated strings in all locales.
   - [x] 2.4 e2e: delete farm with own depots (dialog states consequence, depots handled as stated), foreign-owned depot survives farm deletion, cancel performs no mutation.
 
-- [x] 3. Editor validation and field parity (depends on: none)
+- [x] 3. Editor validation and field parity (depends on: none · model: Claude Sonnet)
   - [x] 3.1 Extend `editor-schema.ts` to legacy joi parity: `url` valid http(s) when present, maxlength 255 (name/city/street/…) and 1000 (description/participation/economicalBehavior/additionalProductInformation), `maximumMembers` non-negative integer, `foundedAtMonth` 1–12; add translated messages (`validations.json` via `translateErrors`) and extend `editor-schema.spec.ts`.
   - [x] 3.2 Add a visible required indicator to required fields (name, city, address via geocoder) in the form components.
   - [x] 3.3 Render badge logos (`badge.logo`, linked `badge.url`) next to editor badge checkboxes, reusing the `BadgesList` presentation.
   - [x] 3.4 Add the account-info box ("this entry is linked to <email>" + edit-account link) to every editor and the initiative editor intro text; i18n in all locales.
 
-- [x] 4. Global toast feedback (sonner) (depends on: none)
+- [x] 4. Global toast feedback (sonner) (depends on: none · model: Claude Sonnet)
   - [x] 4.1 Mount the vendored `ui/sonner` Toaster once in `+layout.svelte`; add `$lib/utils/toast.ts` with success/error helpers taking translated messages.
   - [x] 4.2 Wire auth flows: sign-in success (user's name), sign-out, sign-up confirmation-mail hint, activation/reactivation results in `AccountTokenHandler.svelte`.
   - [x] 4.3 Wire entry create/update success, contact-message sent, and unexpected API errors (destructive toast while inline field errors still render).
   - [x] 4.4 Replace `DepotMutationFeedback.svelte` and the `depotAction` query-param flow with toasts carrying a "show farm" action button; remove the banner component and update `depot-crud.test.ts`.
 
-- [x] 5. Mobile bottom-sheet UX (depends on: none)
+- [x] 5. Mobile bottom-sheet UX (depends on: none · model: Claude Opus)
   - [x] 5.1 Add a snap-point bottom sheet (evaluate `vaul-svelte`) wrapped as a `layout/` component: drag handle, peek/half/full snap points, swipe between them; desktop keeps the current floating sidebar — MapSidebar content unchanged, only the container swaps per breakpoint.
   - [x] 5.2 Wire drawer states: list at peek/half with map pannable, detail opens at half and expands, editors/create-wizard open full-height with sticky save bar above the on-screen keyboard.
   - [x] 5.3 Mobile chrome audit: touch targets ≥44 px, search input above keyboard, safe-area insets, reposition map controls and user nav so nothing overlaps the sheet.
   - [x] 5.4 e2e: new snap-point interaction test on 390×844; keep existing responsive tests (`auth-overlay-responsive`, `responsive-shell-footer`) green.
 
-- [x] 6. Farm↔depot network visualization on the map (depends on: none)
+- [x] 6. Farm↔depot network visualization on the map (depends on: none · model: Claude Opus)
   - [x] 6.1 Build `domain/map/NetworkLayer.svelte`: GeoJSON LineString source computed from the open farm's + its depots' coordinates (from `page.data.detailData`); add line color/width map tokens to `theme-vars.css` for all registered themes.
   - [x] 6.2 Highlight the involved markers (state shared with `SymbolMarkerLayer`) and fit the viewport to the network bounds respecting the sidebar offset when the profile opens.
   - [x] 6.3 Depot selection (marker click, search result, deep link): render the owning farm's network with the selected depot emphasized; remove the layer on profile close; never render for initiatives or depot-less farms.
   - [x] 6.4 e2e covering draw-on-open/remove-on-close and depot-click highlighting; visual check in both theme families.
 
-- [~] 7. Chrome parity odds and ends (depends on: none)
+- [~] 7. Chrome parity odds and ends (depends on: none · model: Claude Sonnet)
   - [x] 7.1 Show an external help link (config `externalHelpUrl`) in `UserNavigation.svelte` for signed-in and signed-out states, opening in a new tab; render nothing when unset.
   - [x] 7.2 Add onboarding intro texts to sign-in and sign-up, including the "this view requires sign-in" variant on redirect from a protected route; i18n in all locales.
   - [x] 7.3 Verify footer/attribution links against legacy (site, privacy, imprint, map data) — done; confirmed via `e2e/responsive-shell-footer.test.ts` that the OpenStreetMap credit already comes from MapLibre's default source attribution and the Mapbox-specific "Improve this map" link is deliberately excluded (this app uses MapLibre, not Mapbox), so no link additions were needed there. `search-widget` stub removal reverted per spec correction (see Additional Notes / PR proposal): the stub should stay until a real use case exists, not be deleted.
 
-- [x] 8. Depots live on the farm profile (depends on: 4)
+- [x] 8. Depots live on the farm profile (depends on: 4 · model: Claude Opus)
   - [x] 8.1 Replace the name-only depot list in `FarmDetail.svelte` with depot cards (name, address, delivery days); tapping a card pans/zooms the map to the depot and highlights its marker; edit/delete actions render only for depots the user owns, foreign-owned depots show an "owned by another account" hint.
   - [x] 8.2 Add "Add pickup location" on the owned farm profile: depot editor opens pre-associated (farm select hidden); create/edit/delete from the profile return to the farm profile with confirm dialog + toast.
   - [x] 8.3 Rework my-entries: depots always grouped under their farm (own depots under own farms; cross-owned depots under the foreign farm's name with the ownership hint); "New depot" shortcut offers only the user's own farms and points users with no farms to creating a farm first.
   - [x] 8.4 Route compat: `#/depots/:id` resolves to the owning farm's profile, `#/depots/new` opens the farm-selection-first flow, `#/depots/:id/edit` opens the depot editor; update `route-compat.ts` + tests.
   - [x] 8.5 e2e: create-from-profile flow, ownership-gated actions on the profile, my-entries grouping incl. the cross-owned legacy case.
 
-- [x] 9. Profile edit mode (inline editing, approximated) (depends on: 1, 2, 3, 4, 8)
+- [x] 9. Profile edit mode (inline editing, approximated) (depends on: 1, 2, 3, 4, 8 · model: Claude Fable)
   - [x] 9.1 Introduce the section architecture: `domain/<type>/sections/` components exporting read + edit variants that share one layout wrapper; sections bind into a single `superForm` instance per profile; drawer decides read vs edit from route kind.
   - [x] 9.2 Decompose the farm profile + `EntryEditor` into sections (header/identity incl. geocoder, description, products, economic behavior, membership, badges, depots — depots section keeps the read view's add/edit/delete affordances in edit mode, no inline depot fields).
   - [x] 9.3 Decompose the initiative profile + editor into its sections the same way.
@@ -60,28 +61,28 @@ Status legend: [ ] todo · [~] in progress · [x] done
   - [x] 9.5 Creation wizard (identity & location → details → membership/goals, type-specific) for `#/farms/new` / `#/initiatives/new`, landing on the new profile in edit mode.
   - [x] 9.6 Remove the classic full-form farm/initiative editor routes/components (depot editor stays a classic compact form); update `inline-edit-create.test.ts`, `unsaved-changes-guard.test.ts`, and the rest of the e2e suite to green.
 
-- [x] 10. Command-style search in the drawer (depends on: 5)
+- [x] 10. Command-style search in the drawer (depends on: 5 · model: Claude Opus)
   - [x] 10.1 Add the shadcn `Command` (cmdk) primitive to `ui/` and rebuild the suggestion panel inline/anchored under the drawer-header input (overlaying the entry list): grouped sections (Locations/Farms/Depots/Initiatives) with type icons, listbox keyboard nav (arrows/Enter/Escape keeping the query), loading state, designed empty state.
   - [x] 10.2 Drawer-state rules: slim persistent header (back + search) while a detail view is open — selecting a result replaces the profile with map pan; no search rendered while an editor or the create wizard is open.
   - [x] 10.3 `/` and `⌘K` shortcuts scoped to the app root element (embed-safe — never capture keystrokes outside the embed host), expanding a collapsed drawer and focusing the search.
   - [x] 10.4 Mobile: focusing the search raises the sheet to full height with keyboard open; dismissing the keyboard returns to the previous snap point. Update `search-discovery.test.ts` + new shortcut/empty-state coverage.
 
-- [x] 11. Entry list and card redesign (depends on: none)
+- [x] 11. Entry list and card redesign (depends on: none · model: Claude Sonnet)
   - [x] 11.1 Redesign `EntryCard.svelte`/`EntriesList.svelte`: type chip (Badge), name, address line, membership status (colored dot + label for farms), product category summary, divider-free layout with hover state; update stories.
   - [x] 11.2 List↔map hover coupling both ways: card hover highlights the marker; marker hover highlights the card and scrolls it into view (desktop).
   - [x] 11.3 Skeleton rows while entries load and a designed empty state with a "reset filters / zoom out" action.
 
-- [x] 12. Detail profile polish (depends on: 9, 10)
+- [x] 12. Detail profile polish (depends on: 9, 10 · model: Claude Sonnet)
   - [x] 12.1 Restructure the profile header: type icon/avatar, name, founded line, membership status chip consistent with card styling; action row (Contact as primary CTA in a sticky drawer footer, Edit for owners, share/copy-link).
   - [x] 12.2 Content sections separated by `Separator` with consistent `typography/` use; products/goals as chip clusters grouped by category instead of `list-disc` bullets.
   - [x] 12.3 Back affordance in the slim persistent drawer header (from 10.2) restoring the previous list scroll position and viewport, in addition to close.
 
-- [x] 13. Map visual language (depends on: none)
+- [x] 13. Map visual language (depends on: none · model: Claude Sonnet)
   - [x] 13.1 Distinct marker hover and selected states in `SymbolMarkerLayer`: selected marker scales/changes color and stays highlighted while its profile is open; hover feedback beyond cursor change.
   - [x] 13.2 Restyle cluster circles/count in `SymbolMarkerCluster` on the token palette.
   - [x] 13.3 Restyle `Popup.svelte` on card tokens (background/foreground, radius scale, shadow) replacing the 0.8-opacity dark box; verify in both themes; keep the zoom indicator dev-gated.
 
-- [x] 14. App chrome & consistency pass (depends on: 5, 6, 10, 11, 12, 13)
+- [x] 14. App chrome & consistency pass (depends on: 5, 6, 10, 11, 12, 13 · model: Claude Opus)
   - [x] 14.1 Decide and land the Track C token adjustments from `design-direction.md` (brand green `--primary`, cream panel background, coral cluster badge, serif-accent yes/no) in `theme-vars.css` + `DESIGN.md` + Storybook token stories; align all floating chrome (user nav pill, sidebar shell, map controls) on one radius/elevation scale.
   - [x] 14.2 `Skeleton`/spinner for every async surface (detail load, my-entries) and designed error states for failed loads.
   - [x] 14.3 Accessibility + spacing sweep: consistent focus-visible rings, focus trap and escape behavior in sheets/dialogs, spacing audited to the `gap-2/4/6` ladder.


### PR DESCRIPTION
Adds `specs/admin-package-improvements/` (spec + implementation plan) from a full audit of `packages/admin`: 13 numbered features covering confirmed react-admin v5 bugs (dead `props.permissions` checks, broken sidebar collapse, wrong transform key), auth-provider hygiene (no logout on 401), dead CRA leftovers, heavy form/filter duplication, UI consistency polish, and one API-side field-permission mismatch. Key findings were verified against the installed react-admin 5.14.7 / ra-data-feathers sources and the API permission matrix. Also annotates each feature in `specs/map-next-parity-ux/plan.md` with a recommended implementer model (Sonnet/Opus/Fable) based on complexity and risk. Docs only — no runtime code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)