### PR TITLE
fix(map-next): show sidebar drawer in embed mode (Shadow DOM z-index)

### DIFF
--- a/packages/map-next/src/routes/layout.css
+++ b/packages/map-next/src/routes/layout.css
@@ -17,7 +17,17 @@
  * with `z-[var(--z-map-overlay)]` etc. Standard low utilities (z-10/z-20) are
  * fine for purely local stacking and don't need a token.
  */
-:root {
+/*
+ * Also target `:host` and `.teikei-shadow-wrapper` so these variables resolve
+ * inside the Shadow DOM used by the embed loader. A bare `:root` never matches
+ * within a shadow tree (the stylesheet is injected into the shadow root, not the
+ * document), which left `z-[var(--z-map-sidebar)]` invalid — degrading to
+ * `z-index: auto` and letting the MapLibre canvas paint over the sidebar shell.
+ * This mirrors how lib/design/theme-vars.css scopes its tokens.
+ */
+:root,
+:host,
+.teikei-shadow-wrapper {
 	--z-map-sidebar: 1000; /* the map sidebar shell */
 	--z-map-overlay: 1200; /* popovers/dropdowns/suggestions over the sidebar */
 	--z-map-controls: 1300; /* floating controls bar over the map */


### PR DESCRIPTION
The map stacking tokens (`--z-map-sidebar`, `--z-map-overlay`, etc.) were defined under a bare `:root {}` selector in `layout.css`, but the embed loader injects the app stylesheet into the shadow root where `:root` matches nothing — so `z-[var(--z-map-sidebar)]` resolved to an invalid `z-index` (`auto`) and the MapLibre canvas painted over the sidebar drawer once the map rendered (it flickered in, then vanished). This scopes the tokens to `:root, :host, .teikei-shadow-wrapper` so they resolve both in the standalone app and inside the embed shadow tree, mirroring how `lib/design/theme-vars.css` scopes its tokens, and also restores `--bottom-sheet-peek-height` for the mobile sheet in embed mode. Verified against the embed build in the browser: both the list and detail drawers now stay visible over the rendered map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)