### PR TITLE
fix(deps): update @feathersjs/commons to 5.0.46

### DIFF
--- a/packages/map/package-lock.json
+++ b/packages/map/package-lock.json
@@ -582,9 +582,9 @@
       }
     },
     "node_modules/@feathersjs/commons": {
-      "version": "5.0.44",
-      "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-5.0.44.tgz",
-      "integrity": "sha512-PnxCyKqzWLAqv1LSazDsOXNf520KQOlqUasZ/9YRz4lYRPJ0pzzfZXvzmjBFOsNPaohzKmyySS8578E9vlTQrA==",
+      "version": "5.0.46",
+      "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-5.0.46.tgz",
+      "integrity": "sha512-jcoPt00VATX25L8eSLLHw75oN0p8ibx0v5KniC/uHlpq5i8CMYgcgjmZJ/bKdkZAHcGQ/ELGvYLkj5QocWpvxg==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"


### PR DESCRIPTION
Updates the transitive `@feathersjs/commons` lockfile entry from 5.0.44 to 5.0.46.

This clears GHSA-28xv-ph75-77wh / CVE-2026-54335. No manifest or application code changes.

Validation:
- `osv-scanner` before: GHSA-28xv-ph75-77wh detected
- `osv-scanner` after: GHSA-28xv-ph75-77wh not detected
- Remaining advisories for `@feathersjs/commons`: none
- `git diff --check`