### PR TITLE
fix(map-next): scope depot ownership notice to farm owners

### DIFF
--- a/packages/map-next/e2e/depot-on-profile.test.ts
+++ b/packages/map-next/e2e/depot-on-profile.test.ts
@@ -234,6 +234,54 @@ test('farm profile gates depot edit/delete to owned depots and deletes from the 
 	expect(page.url()).toContain('#/farms/farm-owned');
 });
 
+test('foreign farm profile shows no ownership hint on any depot card', async ({ page }) => {
+	await mockAuthenticatedUser(page);
+
+	const ownedFarm = buildFarmSummary('farm-owned', 'Owned Farm');
+	const ownedDepot: DepotSeed = {
+		id: 'depot-owned',
+		name: 'My Depot',
+		farmId: 'farm-foreign',
+		farmName: 'Foreign Farm'
+	};
+	const foreignDepot: DepotSeed = {
+		id: 'depot-foreign',
+		name: 'Foreign Depot',
+		farmId: 'farm-foreign',
+		farmName: 'Foreign Farm'
+	};
+
+	await page.route(/\/entries(?:\/)?(?:\?.*)?$/, (route) => {
+		const isMine = new URL(route.request().url()).searchParams.get('mine') === 'true';
+		return fulfillJson(route, {
+			type: 'FeatureCollection',
+			// The user owns a different farm and one depot connected to the foreign farm.
+			features: isMine
+				? [ownedFarm, buildDepotFeature(ownedDepot)]
+				: [ownedFarm, buildFarmSummary('farm-foreign', 'Foreign Farm')]
+		});
+	});
+
+	await page.route(/\/farms\/farm-foreign(?:\/)?(?:\?.*)?$/, (route) =>
+		fulfillJson(route, buildFarmDetail('farm-foreign', 'Foreign Farm', [ownedDepot, foreignDepot]))
+	);
+
+	await page.goto('/#/farms/farm-foreign');
+
+	const ownedCard = page.locator('[data-testid="depot-card"][data-depot-id="depot-owned"]');
+	const foreignCard = page.locator('[data-testid="depot-card"][data-depot-id="depot-foreign"]');
+	await expect(ownedCard).toBeVisible({ timeout: 15000 });
+	await expect(foreignCard).toBeVisible({ timeout: 15000 });
+
+	// The hint is farm-owner-scoped: on a foreign farm no card shows it.
+	await expect(page.getByTestId('depot-card-foreign-hint')).toHaveCount(0);
+
+	// Owned depots keep their management actions even on a foreign farm.
+	await expect(ownedCard.getByTestId('depot-card-edit')).toBeVisible();
+	await expect(foreignCard.getByTestId('depot-card-edit')).toHaveCount(0);
+	await expect(foreignCard.getByTestId('depot-card-delete')).toHaveCount(0);
+});
+
 test('farm profile collapses a long depot list to five rows behind a show-all toggle', async ({
 	page
 }) => {

--- a/packages/map-next/src/lib/components/domain/farms/sections/FarmDepotsSection.svelte
+++ b/packages/map-next/src/lib/components/domain/farms/sections/FarmDepotsSection.svelte
@@ -110,7 +110,7 @@
 									{m.map_sidebar_action_delete()}
 								</AppButton>
 							</div>
-						{:else}
+						{:else if isFarmOwner}
 							<span
 								class="shrink-0 text-xs text-muted-foreground"
 								data-testid="depot-card-foreign-hint"

--- a/specs/depot-handling-improvements/plan.md
+++ b/specs/depot-handling-improvements/plan.md
@@ -21,9 +21,9 @@ suggested model — **fable** (fast, mechanical), **sonnet** (moderate feature w
   - [ ] 2.3 Render already-connected foreign farms as removable chips (the combobox already renders selected values as removable); confirm removal + save works even when the foreign checkbox is toggled off.
   - [ ] 2.4 Add coverage: editing an owned-only depot → checkbox unchecked, owned-only options; editing a depot with a foreign connection → checkbox pre-enabled, foreign farm shown as removable chip, removal persists on save.
 
-- [ ] 3. Farm-owner-scoped "managed by another account" notice (depends on: none) — model: fable
-  - [ ] 3.1 In `FarmDepotsSection.svelte`, gate the `details_depot_owned_by_other` branch on `isFarmOwner && !isOwned` (currently shows on any non-owned depot regardless of farm ownership).
-  - [ ] 3.2 Add coverage: notice appears on a foreign depot when viewing an owned farm; notice absent for every depot when viewing a foreign farm.
+- [x] 3. Farm-owner-scoped "managed by another account" notice (depends on: none) — model: fable
+  - [x] 3.1 In `FarmDepotsSection.svelte`, gate the `details_depot_owned_by_other` branch on `isFarmOwner && !isOwned` (currently shows on any non-owned depot regardless of farm ownership).
+  - [x] 3.2 Add coverage: notice appears on a foreign depot when viewing an owned farm; notice absent for every depot when viewing a foreign farm.
 
 - [ ] 4. "Add depot" button restricted to owned farms (verify) (depends on: none) — model: fable
   - [ ] 4.1 Verify `farm-add-depot` renders only when `isFarmOwner` in `FarmDepotsSection.svelte` / its wiring in `FarmProfile.svelte` + `MapSidebar.svelte`; fix if a gap is found.


### PR DESCRIPTION
Implements Feature 3 of `specs/depot-handling-improvements` (spec/plan merged in #881): the "Wird von einem anderen Konto verwaltet." hint on depot cards in `FarmDepotsSection.svelte` is now gated on `isFarmOwner`, so it only appears when viewing a farm you own that has depots managed by another account — on foreign farm profiles no card shows it. Adds an e2e test covering the foreign-farm case (no hint on any card; owned depots keep edit/delete), complementing the existing owned-farm gating test, and checks off Feature 3 in plan.md.

## Verification

- `svelte-check`: 0 errors; Prettier/ESLint clean.
- All 6 e2e tests in `depot-on-profile.test.ts` pass, including the new one.
- Both spec acceptance criteria checked explicitly (owned farm shows the notice on foreign depots; foreign farm shows none).

## Review

Independent high-effort review pass (8 finder angles, adversarial verification) surfaced one PLAUSIBLE low-severity note, not applied: the assertion at `e2e/depot-on-profile.test.ts:280` uses Playwright's default 5s timeout while depending on the auth → my-entries chain; the pre-existing sibling test uses the identical pattern, so it matches file convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)