### PR TITLE
test(map-next): lock add-depot button to farm owners

### DIFF
--- a/packages/map-next/e2e/depot-on-profile.test.ts
+++ b/packages/map-next/e2e/depot-on-profile.test.ts
@@ -234,6 +234,40 @@ test('farm profile gates depot edit/delete to owned depots and deletes from the 
 	expect(page.url()).toContain('#/farms/farm-owned');
 });
 
+test('the add-depot button is absent on a foreign farm profile', async ({ page }) => {
+	await mockAuthenticatedUser(page);
+
+	const foreignFarm = buildFarmSummary('farm-foreign', 'Foreign Farm');
+	// The signed-in user owns a depot connected to the farm, but not the farm itself.
+	const ownedDepot: DepotSeed = {
+		id: 'depot-owned',
+		name: 'My Depot',
+		farmId: 'farm-foreign',
+		farmName: 'Foreign Farm'
+	};
+
+	await page.route(/\/entries(?:\/)?(?:\?.*)?$/, (route) => {
+		const isMine = new URL(route.request().url()).searchParams.get('mine') === 'true';
+		return fulfillJson(route, {
+			type: 'FeatureCollection',
+			features: isMine ? [buildDepotFeature(ownedDepot)] : [foreignFarm]
+		});
+	});
+
+	await page.route(/\/farms\/farm-foreign(?:\/)?(?:\?.*)?$/, (route) =>
+		fulfillJson(route, buildFarmDetail('farm-foreign', 'Foreign Farm', [ownedDepot]))
+	);
+
+	await page.goto('/#/farms/farm-foreign');
+
+	// The owned depot's edit affordance renders only once auth and the mine=true
+	// entries response have resolved, anchoring the absence check below to a
+	// settled authenticated-ownership state (not a not-yet-loaded one).
+	const ownedCard = page.locator('[data-testid="depot-card"][data-depot-id="depot-owned"]');
+	await expect(ownedCard.getByTestId('depot-card-edit')).toBeVisible({ timeout: 15000 });
+	await expect(page.getByTestId('farm-add-depot')).toHaveCount(0);
+});
+
 test('farm profile collapses a long depot list to five rows behind a show-all toggle', async ({
 	page
 }) => {

--- a/specs/depot-handling-improvements/plan.md
+++ b/specs/depot-handling-improvements/plan.md
@@ -25,9 +25,9 @@ suggested model — **fable** (fast, mechanical), **sonnet** (moderate feature w
   - [ ] 3.1 In `FarmDepotsSection.svelte`, gate the `details_depot_owned_by_other` branch on `isFarmOwner && !isOwned` (currently shows on any non-owned depot regardless of farm ownership).
   - [ ] 3.2 Add coverage: notice appears on a foreign depot when viewing an owned farm; notice absent for every depot when viewing a foreign farm.
 
-- [ ] 4. "Add depot" button restricted to owned farms (verify) (depends on: none) — model: fable
-  - [ ] 4.1 Verify `farm-add-depot` renders only when `isFarmOwner` in `FarmDepotsSection.svelte` / its wiring in `FarmProfile.svelte` + `MapSidebar.svelte`; fix if a gap is found.
-  - [ ] 4.2 Add/confirm coverage: add-depot button present on an owned farm profile, absent on a foreign farm profile.
+- [x] 4. "Add depot" button restricted to owned farms (verify) (depends on: none) — model: fable
+  - [x] 4.1 Verify `farm-add-depot` renders only when `isFarmOwner` in `FarmDepotsSection.svelte` / its wiring in `FarmProfile.svelte` + `MapSidebar.svelte`; fix if a gap is found.
+  - [x] 4.2 Add/confirm coverage: add-depot button present on an owned farm profile, absent on a foreign farm profile.
 
 - [ ] 5. Expanded depot info via per-depot accordion (depends on: 3) — model: sonnet
   - [ ] 5.1 Add a thin `src/lib/components/ui/accordion` (or `collapsible`) wrapper over the existing `bits-ui` primitive, matching the conventions of sibling `ui/` wrappers.


### PR DESCRIPTION
Implements Feature 4 of `specs/depot-handling-improvements` — '"Add depot" button restricted to owned farms (verify)'.

- **4.1 (verify gating):** Confirmed the chain is intact with no gap: `FarmDepotsSection.svelte` renders the button only when `isFarmOwner && onAddDepot`; `FarmProfile.svelte` passes `isFarmOwner={canEdit}`; `MapSidebar.svelte` derives `canEdit` from `ownedMainEntryIds` built from `entries?mine=true`. No code change needed.
- **4.2 (coverage):** Added an e2e test asserting the add-depot CTA is absent on a foreign farm's profile. The absence assertion is anchored to a settled auth/ownership state by waiting for an owned depot's edit affordance (renders only after auth succeeds and `mine=true` resolves), so it can't pass vacuously or race the ownership load. Presence on an owned farm was already covered in the same file.
- **Checks:** `depot-on-profile.test.ts` 6/6 passing, prettier + eslint clean. Plan checkboxes for feature 4 marked done.
- **Review:** independent code review ran; 3 findings applied (assertion sync, auth anchoring, redundant assertion removed), 1 informational altitude note intentionally not applied (e2e matches sibling ownership-gate tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)