### PR TITLE
feat(map-next): owned-farms-first depot selector with opt-in foreign connection

### DIFF
--- a/packages/map-next/e2e/depot-crud.test.ts
+++ b/packages/map-next/e2e/depot-crud.test.ts
@@ -70,6 +70,7 @@ async function mockAuthenticatedUser(page: Page) {
 
 async function mockDepotCrudApi(page: Page) {
 	const ownedFarm = buildFarmFeature('farm-owned', 'Owned Farm');
+	const foreignFarm = buildFarmFeature('farm-foreign', 'Foreign Farm');
 	let ownedDepot: ReturnType<typeof buildDepotFeature> | null = buildDepotFeature(
 		'depot-owned',
 		'Owned Depot',
@@ -89,7 +90,7 @@ async function mockDepotCrudApi(page: Page) {
 
 		return fulfillJson(route, {
 			type: 'FeatureCollection',
-			features: ownedDepot ? [ownedFarm, ownedDepot] : [ownedFarm]
+			features: ownedDepot ? [ownedFarm, foreignFarm, ownedDepot] : [ownedFarm, foreignFarm]
 		});
 	});
 
@@ -223,6 +224,29 @@ test('depot editor farm combobox: mouse click selects an option and the chip is 
 	// The chip's remove control clears the selection.
 	await chipRemove.click();
 	await expect(chipRemove).toBeHidden();
+});
+
+test('depot editor farm combobox defaults to owned farms and reveals all once opted in', async ({
+	page
+}) => {
+	await mockAuthenticatedUser(page);
+	await mockDepotCrudApi(page);
+
+	await page.goto('/#/myentries');
+	await page.getByTestId('create-depot-action').click();
+
+	await expect.poll(() => page.url(), { timeout: 15000 }).toContain('#/depots/new');
+	await expect(page.getByTestId('depot-editor')).toBeVisible({ timeout: 15000 });
+
+	const farmsInput = page.getByTestId('depot-input-farms');
+	await farmsInput.click();
+	await expect(page.getByRole('option', { name: 'Owned Farm' })).toBeVisible({ timeout: 15000 });
+	await expect(page.getByRole('option', { name: 'Foreign Farm' })).toBeHidden();
+	await farmsInput.press('Escape');
+
+	await page.getByTestId('depot-input-connect-foreign-farms').click();
+	await farmsInput.click();
+	await expect(page.getByRole('option', { name: 'Foreign Farm' })).toBeVisible({ timeout: 15000 });
 });
 
 test('edit and delete depot in my-entries keep management context and show success feedback', async ({

--- a/packages/map-next/messages/de-at.json
+++ b/packages/map-next/messages/de-at.json
@@ -170,6 +170,8 @@
 	"editor_section_goals": "Wir suchen",
 	"editor_error_summary": "Bitte überprüfe die Angaben in: {sections}",
 	"editor_depot_field_farms": "Zugehörige Höfe",
+	"editor_depot_own_farm_hint": "Ein Depot wird in der Regel mit deinem eigenen Hof verbunden.",
+	"editor_depot_connect_foreign_farms": "Auch fremde Höfe verbinden",
 	"editor_depot_no_farms_available": "Keine Höfe verfügbar.",
 	"editor_depot_farms_placeholder": "Höfe suchen …",
 	"editor_depot_farms_empty": "Keine Höfe gefunden.",

--- a/packages/map-next/messages/de-ch.json
+++ b/packages/map-next/messages/de-ch.json
@@ -170,6 +170,8 @@
 	"editor_section_goals": "Wir suchen",
 	"editor_error_summary": "Bitte überprüfe die Angaben in: {sections}",
 	"editor_depot_field_farms": "Zugehörige Höfe",
+	"editor_depot_own_farm_hint": "Ein Depot wird in der Regel mit deinem eigenen Hof verbunden.",
+	"editor_depot_connect_foreign_farms": "Auch fremde Höfe verbinden",
 	"editor_depot_no_farms_available": "Keine Höfe verfügbar.",
 	"editor_depot_farms_placeholder": "Höfe suchen …",
 	"editor_depot_farms_empty": "Keine Höfe gefunden.",

--- a/packages/map-next/messages/de-de.json
+++ b/packages/map-next/messages/de-de.json
@@ -170,6 +170,8 @@
 	"editor_section_goals": "Wir suchen",
 	"editor_error_summary": "Bitte überprüfe die Angaben in: {sections}",
 	"editor_depot_field_farms": "Zugehörige Höfe",
+	"editor_depot_own_farm_hint": "Ein Depot wird in der Regel mit deinem eigenen Hof verbunden.",
+	"editor_depot_connect_foreign_farms": "Auch fremde Höfe verbinden",
 	"editor_depot_no_farms_available": "Keine Höfe verfügbar.",
 	"editor_depot_farms_placeholder": "Höfe suchen …",
 	"editor_depot_farms_empty": "Keine Höfe gefunden.",

--- a/packages/map-next/messages/fr-ch.json
+++ b/packages/map-next/messages/fr-ch.json
@@ -170,6 +170,8 @@
 	"editor_section_goals": "Nous recherchons",
 	"editor_error_summary": "Veuillez vérifier les informations dans : {sections}",
 	"editor_depot_field_farms": "Fermes associées",
+	"editor_depot_own_farm_hint": "En général, un dépôt est associé à votre propre ferme.",
+	"editor_depot_connect_foreign_farms": "Associer aussi des fermes tierces",
 	"editor_depot_no_farms_available": "Aucune ferme disponible.",
 	"editor_depot_farms_placeholder": "Rechercher des fermes …",
 	"editor_depot_farms_empty": "Aucune ferme trouvée.",

--- a/packages/map-next/src/lib/components/domain/depots/DepotEditor.svelte
+++ b/packages/map-next/src/lib/components/domain/depots/DepotEditor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
 	import * as Field from '$lib/components/ui/field';
+	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Paragraph } from '$lib/components/typography';
 	import {
 		EditorAccountInfo,
@@ -62,8 +63,25 @@
 	let isSaving = $state(false);
 	const hasUnsavedChanges = $derived(hasTaintedField($tainted));
 	const farmsError = $derived(translateErrors($errors.farms?._errors));
+
+	// Connecting a foreign farm is a deliberate opt-in; unchecked by default.
+	let connectForeignFarms = $state(false);
+	// A farm already selected before the checkbox is unchecked stays visible as a
+	// removable chip instead of silently remaining in $formData.farms unseen.
+	const selectedForeignFarmOptions = $derived(
+		editorData.allFarmOptions.filter(
+			(option) =>
+				$formData.farms.includes(option.id) &&
+				!editorData.farmOptions.some((owned) => owned.id === option.id)
+		)
+	);
+	const farmOptionsInScope = $derived(
+		connectForeignFarms
+			? editorData.allFarmOptions
+			: [...editorData.farmOptions, ...selectedForeignFarmOptions]
+	);
 	const farmComboboxOptions = $derived(
-		editorData.farmOptions.map((option) => ({ value: option.id, label: option.name }))
+		farmOptionsInScope.map((option) => ({ value: option.id, label: option.name }))
 	);
 
 	const guard = createEditorGuard({
@@ -175,7 +193,10 @@
 			{:else}
 				<Field.Field data-invalid={!!farmsError}>
 					<Field.Label for="depot-editor-farms">{m.editor_depot_field_farms()}</Field.Label>
-					{#if editorData.farmOptions.length === 0}
+					{#if editorData.mode === 'create'}
+						<Field.Description>{m.editor_depot_own_farm_hint()}</Field.Description>
+					{/if}
+					{#if farmOptionsInScope.length === 0}
 						<Field.Description>{m.editor_depot_no_farms_available()}</Field.Description>
 					{:else}
 						<MultiSelectCombobox
@@ -193,6 +214,18 @@
 						<Field.Error>{farmsError}</Field.Error>
 					{/if}
 				</Field.Field>
+				{#if editorData.mode === 'create'}
+					<Field.Field orientation="horizontal">
+						<Checkbox
+							id="depot-editor-connect-foreign-farms"
+							data-testid="depot-input-connect-foreign-farms"
+							bind:checked={connectForeignFarms}
+						/>
+						<Field.Label for="depot-editor-connect-foreign-farms" class="font-normal">
+							{m.editor_depot_connect_foreign_farms()}
+						</Field.Label>
+					</Field.Field>
+				{/if}
 			{/if}
 
 			<GeocoderField

--- a/packages/map-next/src/lib/types/editor.ts
+++ b/packages/map-next/src/lib/types/editor.ts
@@ -17,5 +17,8 @@ export interface DepotFarmOption {
 
 export interface DepotEditorData {
 	mode: EntryEditorMode;
+	/** Farms the current user owns — the default, restricted option source. */
 	farmOptions: DepotFarmOption[];
+	/** All farms, offered only once the user opts in to connecting a foreign farm. */
+	allFarmOptions: DepotFarmOption[];
 }

--- a/packages/map-next/src/routes/depots/[id]/edit/+page.ts
+++ b/packages/map-next/src/routes/depots/[id]/edit/+page.ts
@@ -28,9 +28,13 @@ export const load: PageLoad = ({ params, parent }) => {
 	return loadCatching(routeBuilders.depotLegacy.edit(params.id), async () => {
 		const { entries } = await parent();
 		const detailData = await getDepotEntry(params.id);
+		// TODO(feature 2): split into owned vs. all farm options; all farms are
+		// offered unrestricted here until the edit-mode ownership split lands.
+		const allFarmOptions = getFarmOptions(entries);
 		const editorData: DepotEditorData = {
 			mode: 'edit',
-			farmOptions: getFarmOptions(entries)
+			farmOptions: allFarmOptions,
+			allFarmOptions
 		};
 
 		return { depotDetailData: detailData, depotEditorData: editorData };

--- a/packages/map-next/src/routes/depots/new/+page.ts
+++ b/packages/map-next/src/routes/depots/new/+page.ts
@@ -38,21 +38,24 @@ export const load: PageLoad = ({ parent, url }) => {
 			const presetFarm = entries.features.find(
 				(feature) => feature.properties.type === 'Farm' && feature.properties.id === presetFarmId
 			);
+			const presetFarmOptions = presetFarm
+				? [{ id: presetFarm.properties.id, name: presetFarm.properties.name }]
+				: [];
 			const editorData: DepotEditorData = {
 				mode: 'create',
-				farmOptions: presetFarm
-					? [{ id: presetFarm.properties.id, name: presetFarm.properties.name }]
-					: []
+				farmOptions: presetFarmOptions,
+				allFarmOptions: presetFarmOptions
 			};
 			return { depotEditorData: editorData };
 		}
 
-		// Farm-selection-first flow: only the user's own farms can host a new depot,
-		// so new farm+depot networks are always single-owner (Feature 8).
-		const myEntries = await getMyEntries();
+		// Farm-selection-first flow: owned farms are the default option source;
+		// all farms are offered only once the user opts in to a foreign connection.
+		const [myEntries, { entries }] = await Promise.all([getMyEntries(), parent()]);
 		const editorData: DepotEditorData = {
 			mode: 'create',
-			farmOptions: getFarmOptions(myEntries)
+			farmOptions: getFarmOptions(myEntries),
+			allFarmOptions: getFarmOptions(entries)
 		};
 
 		return { depotEditorData: editorData };

--- a/specs/depot-handling-improvements/plan.md
+++ b/specs/depot-handling-improvements/plan.md
@@ -8,12 +8,12 @@ Model recommendation legend (implementation agent): each feature is tagged with 
 suggested model — **fable** (fast, mechanical), **sonnet** (moderate feature work),
 **opus** (hardest reasoning / map internals).
 
-- [ ] 1. Owned-farms-first farm selector with opt-in foreign connection (depends on: none) — model: sonnet
-  - [ ] 1.1 Extend `DepotEditorData`/`DepotFarmOption` (`src/lib/types/editor.ts`) so the editor receives owned-farm options separately from all-farm options (e.g. `farmOptions` = owned, plus `allFarmOptions`, or an `owned` flag per option).
-  - [ ] 1.2 Update the create loader (`src/routes/depots/new/+page.ts`) to supply both owned farms (`getMyEntries`) and the full farm set (`getEntries`) via the extended editor data; keep preset-farm flow unchanged.
-  - [ ] 1.3 In `DepotEditor.svelte`, add a "connect foreign farms" checkbox (new message key) that switches the `MultiSelectCombobox` option source between owned-only and all farms; default unchecked. Hide/skip when `isPresetFarm`.
-  - [ ] 1.4 Ensure foreign farms are not selectable while unchecked (filter options), and add helper text (new message key) stating the expected default is your own farm.
-  - [ ] 1.5 Add/extend Playwright (or component) coverage: create form defaults to owned-only options; checkbox reveals all farms.
+- [x] 1. Owned-farms-first farm selector with opt-in foreign connection (depends on: none) — model: sonnet
+  - [x] 1.1 Extend `DepotEditorData`/`DepotFarmOption` (`src/lib/types/editor.ts`) so the editor receives owned-farm options separately from all-farm options (e.g. `farmOptions` = owned, plus `allFarmOptions`, or an `owned` flag per option).
+  - [x] 1.2 Update the create loader (`src/routes/depots/new/+page.ts`) to supply both owned farms (`getMyEntries`) and the full farm set (`getEntries`) via the extended editor data; keep preset-farm flow unchanged.
+  - [x] 1.3 In `DepotEditor.svelte`, add a "connect foreign farms" checkbox (new message key) that switches the `MultiSelectCombobox` option source between owned-only and all farms; default unchecked. Hide/skip when `isPresetFarm`.
+  - [x] 1.4 Ensure foreign farms are not selectable while unchecked (filter options), and add helper text (new message key) stating the expected default is your own farm.
+  - [x] 1.5 Add/extend Playwright (or component) coverage: create form defaults to owned-only options; checkbox reveals all farms.
 
 - [ ] 2. Consistent owned-farm restriction + foreign chips in edit mode (depends on: 1) — model: sonnet
   - [ ] 2.1 Update the edit loader (`src/routes/depots/[id]/edit/+page.ts`) to supply owned vs. all farm options (mirror 1.1/1.2), replacing the current all-farms-only `getEntries` behavior.


### PR DESCRIPTION
## Summary
- Depot create form's farm combobox now defaults to the current user's own farms; a new "connect foreign farms" checkbox (unchecked by default) is required to reveal and select from all farms, making foreign-farm connection a deliberate opt-in rather than the previous unrestricted list.
- Already-selected foreign farms stay visible as removable chips even if the checkbox is later unchecked, so a prior selection is never silently dropped or silently retained without the user seeing it.
- Preset-farm create flow (from a farm profile) and edit mode are unchanged for now — edit mode's owned/foreign split is deferred to a follow-up feature (tracked via a TODO in the edit loader).
- Adds new German/French message keys for the checkbox label and helper text, and Playwright coverage for the owned-only default and checkbox-reveals-all-farms behavior.

Implements feature 1 of `specs/depot-handling-improvements`.

## Test plan
- [x] `npm run check` (svelte-check, 0 errors)
- [x] `npx vitest run` (95 passed)
- [x] `npx playwright test e2e/depot-crud.test.ts e2e/depot-on-profile.test.ts e2e/depot-interaction.test.ts` (12 passed)
- [x] Independent code review pass (findings fixed: checkbox scoped to create mode, no color bleed from the farms-invalid state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)