### PR TITLE
feat(map-next): consistent owned-farm restriction in depot edit mode

### DIFF
--- a/packages/map-next/e2e/depot-crud.test.ts
+++ b/packages/map-next/e2e/depot-crud.test.ts
@@ -27,7 +27,7 @@ function buildFarmFeature(id: string, name: string) {
 	};
 }
 
-function buildDepotFeature(id: string, name: string, farmId: string, farmName: string) {
+function buildDepotFeature(id: string, name: string, farms: Array<{ id: string; name: string }>) {
 	return {
 		type: 'Feature' as const,
 		geometry: { type: 'Point' as const, coordinates: [8.58, 47.39] },
@@ -44,7 +44,7 @@ function buildDepotFeature(id: string, name: string, farmId: string, farmName: s
 			deliveryDays: '',
 			farms: {
 				type: 'FeatureCollection' as const,
-				features: [buildFarmFeature(farmId, farmName)]
+				features: farms.map((farm) => buildFarmFeature(farm.id, farm.name))
 			},
 			updatedAt: '2025-02-02T00:00:00.000Z'
 		}
@@ -68,14 +68,22 @@ async function mockAuthenticatedUser(page: Page) {
 	);
 }
 
-async function mockDepotCrudApi(page: Page) {
+async function mockDepotCrudApi(page: Page, initialFarmIds: string[] = ['farm-owned']) {
 	const ownedFarm = buildFarmFeature('farm-owned', 'Owned Farm');
 	const foreignFarm = buildFarmFeature('farm-foreign', 'Foreign Farm');
+	const farmsById = new Map([ownedFarm, foreignFarm].map((farm) => [farm.properties.id, farm]));
+
+	function resolveFarms(farmIds: string[]) {
+		return farmIds.map((id) => {
+			const farm = farmsById.get(id);
+			return { id, name: farm?.properties.name ?? id };
+		});
+	}
+
 	let ownedDepot: ReturnType<typeof buildDepotFeature> | null = buildDepotFeature(
 		'depot-owned',
 		'Owned Depot',
-		'farm-owned',
-		'Owned Farm'
+		resolveFarms(initialFarmIds)
 	);
 
 	await page.route(/\/entries(?:\/)?(?:\?.*)?$/, (route) => {
@@ -101,8 +109,7 @@ async function mockDepotCrudApi(page: Page) {
 			ownedDepot = buildDepotFeature(
 				'depot-owned',
 				payload.name ?? 'Owned Depot',
-				'farm-owned',
-				'Owned Farm'
+				resolveFarms(payload.farms ?? initialFarmIds)
 			);
 			await fulfillJson(route, ownedDepot);
 			return;
@@ -110,7 +117,7 @@ async function mockDepotCrudApi(page: Page) {
 
 		if (method === 'DELETE') {
 			const deleted =
-				ownedDepot ?? buildDepotFeature('depot-owned', 'Owned Depot', 'farm-owned', 'Owned Farm');
+				ownedDepot ?? buildDepotFeature('depot-owned', 'Owned Depot', resolveFarms(initialFarmIds));
 			ownedDepot = null;
 			await fulfillJson(route, deleted);
 			return;
@@ -118,7 +125,7 @@ async function mockDepotCrudApi(page: Page) {
 
 		await fulfillJson(
 			route,
-			ownedDepot ?? buildDepotFeature('depot-owned', 'Owned Depot', 'farm-owned', 'Owned Farm')
+			ownedDepot ?? buildDepotFeature('depot-owned', 'Owned Depot', resolveFarms(initialFarmIds))
 		);
 	});
 
@@ -131,8 +138,7 @@ async function mockDepotCrudApi(page: Page) {
 		ownedDepot = buildDepotFeature(
 			'depot-created',
 			payload.name ?? 'Created Depot',
-			'farm-owned',
-			'Owned Farm'
+			resolveFarms(payload.farms ?? ['farm-owned'])
 		);
 		await fulfillJson(route, ownedDepot);
 	});
@@ -287,4 +293,48 @@ test('edit and delete depot in my-entries keep management context and show succe
 		page.locator('[data-sonner-toast]').filter({ hasText: 'Depot wurde gelöscht.' })
 	).toBeVisible({ timeout: 15000 });
 	await expect(page.getByText(depotState.getOwnedDepotName())).toBeHidden();
+});
+
+test('editing an owned-only depot shows the foreign-farm checkbox unchecked and owned-only options', async ({
+	page
+}) => {
+	await mockAuthenticatedUser(page);
+	await mockDepotCrudApi(page, ['farm-owned']);
+
+	await page.goto('/#/depots/depot-owned/edit');
+	await expect(page.getByTestId('depot-editor')).toBeVisible({ timeout: 15000 });
+
+	await expect(page.getByTestId('depot-input-connect-foreign-farms')).not.toBeChecked();
+	await expect(page.getByRole('button', { name: 'Entfernen: Owned Farm' })).toBeVisible({
+		timeout: 15000
+	});
+
+	const farmsInput = page.getByTestId('depot-input-farms');
+	await farmsInput.click();
+	await expect(page.getByRole('option', { name: 'Foreign Farm' })).toBeHidden();
+});
+
+test('editing a depot with a foreign farm connection pre-enables the checkbox, shows a removable chip, and removal persists on save', async ({
+	page
+}) => {
+	await mockAuthenticatedUser(page);
+	await mockDepotCrudApi(page, ['farm-owned', 'farm-foreign']);
+
+	await page.goto('/#/depots/depot-owned/edit');
+	await expect(page.getByTestId('depot-editor')).toBeVisible({ timeout: 15000 });
+
+	await expect(page.getByTestId('depot-input-connect-foreign-farms')).toBeChecked();
+
+	const foreignChipRemove = page.getByRole('button', { name: 'Entfernen: Foreign Farm' });
+	await expect(foreignChipRemove).toBeVisible({ timeout: 15000 });
+	await expect(page.getByRole('button', { name: 'Entfernen: Owned Farm' })).toBeVisible();
+
+	await foreignChipRemove.click();
+	await expect(foreignChipRemove).toBeHidden();
+
+	await page.getByTestId('depot-editor-save').click();
+
+	await expect(
+		page.locator('[data-sonner-toast]').filter({ hasText: 'Depot wurde aktualisiert.' })
+	).toBeVisible({ timeout: 15000 });
 });

--- a/packages/map-next/src/lib/components/domain/depots/DepotEditor.svelte
+++ b/packages/map-next/src/lib/components/domain/depots/DepotEditor.svelte
@@ -64,8 +64,16 @@
 	const hasUnsavedChanges = $derived(hasTaintedField($tainted));
 	const farmsError = $derived(translateErrors($errors.farms?._errors));
 
-	// Connecting a foreign farm is a deliberate opt-in; unchecked by default.
-	let connectForeignFarms = $state(false);
+	// Connecting a foreign farm is a deliberate opt-in; unchecked by default in
+	// create mode, auto-enabled in edit mode when a foreign farm is already
+	// connected so its chip isn't hidden behind an unchecked box.
+	// svelte-ignore state_referenced_locally
+	let connectForeignFarms = $state(
+		editorData.mode === 'edit' &&
+			initialFormData.farms.some(
+				(farmId) => !editorData.farmOptions.some((owned) => owned.id === farmId)
+			)
+	);
 	// A farm already selected before the checkbox is unchecked stays visible as a
 	// removable chip instead of silently remaining in $formData.farms unseen.
 	const selectedForeignFarmOptions = $derived(
@@ -214,18 +222,16 @@
 						<Field.Error>{farmsError}</Field.Error>
 					{/if}
 				</Field.Field>
-				{#if editorData.mode === 'create'}
-					<Field.Field orientation="horizontal">
-						<Checkbox
-							id="depot-editor-connect-foreign-farms"
-							data-testid="depot-input-connect-foreign-farms"
-							bind:checked={connectForeignFarms}
-						/>
-						<Field.Label for="depot-editor-connect-foreign-farms" class="font-normal">
-							{m.editor_depot_connect_foreign_farms()}
-						</Field.Label>
-					</Field.Field>
-				{/if}
+				<Field.Field orientation="horizontal">
+					<Checkbox
+						id="depot-editor-connect-foreign-farms"
+						data-testid="depot-input-connect-foreign-farms"
+						bind:checked={connectForeignFarms}
+					/>
+					<Field.Label for="depot-editor-connect-foreign-farms" class="font-normal">
+						{m.editor_depot_connect_foreign_farms()}
+					</Field.Label>
+				</Field.Field>
 			{/if}
 
 			<GeocoderField

--- a/packages/map-next/src/routes/depots/[id]/edit/+page.ts
+++ b/packages/map-next/src/routes/depots/[id]/edit/+page.ts
@@ -2,12 +2,13 @@ import type { PageLoad } from './$types';
 import { redirect } from '@sveltejs/kit';
 import { getDepotEntry } from '$lib/api/entry-details';
 import { getAccessToken } from '$lib/utils/localStorage';
+import { getMyEntries } from '$lib/api/entries';
 import { loadCatching } from '$lib/utils/load-error';
 import { routeBuilders } from '$lib/utils/routes';
 import type { EntryFeatureCollection } from '$lib/types/entries';
-import type { DepotEditorData } from '$lib/types/editor';
+import type { DepotEditorData, DepotFarmOption } from '$lib/types/editor';
 
-function getFarmOptions(entries: EntryFeatureCollection) {
+function getFarmOptions(entries: EntryFeatureCollection): DepotFarmOption[] {
 	return entries.features
 		.filter((feature) => feature.properties.type === 'Farm')
 		.map((feature) => ({
@@ -26,15 +27,15 @@ export const load: PageLoad = ({ params, parent }) => {
 	}
 
 	return loadCatching(routeBuilders.depotLegacy.edit(params.id), async () => {
-		const { entries } = await parent();
-		const detailData = await getDepotEntry(params.id);
-		// TODO(feature 2): split into owned vs. all farm options; all farms are
-		// offered unrestricted here until the edit-mode ownership split lands.
-		const allFarmOptions = getFarmOptions(entries);
+		const [{ entries }, myEntries, detailData] = await Promise.all([
+			parent(),
+			getMyEntries(),
+			getDepotEntry(params.id)
+		]);
 		const editorData: DepotEditorData = {
 			mode: 'edit',
-			farmOptions: allFarmOptions,
-			allFarmOptions
+			farmOptions: getFarmOptions(myEntries),
+			allFarmOptions: getFarmOptions(entries)
 		};
 
 		return { depotDetailData: detailData, depotEditorData: editorData };

--- a/specs/depot-handling-improvements/plan.md
+++ b/specs/depot-handling-improvements/plan.md
@@ -15,11 +15,11 @@ suggested model — **fable** (fast, mechanical), **sonnet** (moderate feature w
   - [x] 1.4 Ensure foreign farms are not selectable while unchecked (filter options), and add helper text (new message key) stating the expected default is your own farm.
   - [x] 1.5 Add/extend Playwright (or component) coverage: create form defaults to owned-only options; checkbox reveals all farms.
 
-- [ ] 2. Consistent owned-farm restriction + foreign chips in edit mode (depends on: 1) — model: sonnet
-  - [ ] 2.1 Update the edit loader (`src/routes/depots/[id]/edit/+page.ts`) to supply owned vs. all farm options (mirror 1.1/1.2), replacing the current all-farms-only `getEntries` behavior.
-  - [ ] 2.2 In `DepotEditor.svelte`, on edit-mode init, auto-enable the foreign-farm checkbox when any currently-connected farm is not in the owned set.
-  - [ ] 2.3 Render already-connected foreign farms as removable chips (the combobox already renders selected values as removable); confirm removal + save works even when the foreign checkbox is toggled off.
-  - [ ] 2.4 Add coverage: editing an owned-only depot → checkbox unchecked, owned-only options; editing a depot with a foreign connection → checkbox pre-enabled, foreign farm shown as removable chip, removal persists on save.
+- [x] 2. Consistent owned-farm restriction + foreign chips in edit mode (depends on: 1) — model: sonnet
+  - [x] 2.1 Update the edit loader (`src/routes/depots/[id]/edit/+page.ts`) to supply owned vs. all farm options (mirror 1.1/1.2), replacing the current all-farms-only `getEntries` behavior.
+  - [x] 2.2 In `DepotEditor.svelte`, on edit-mode init, auto-enable the foreign-farm checkbox when any currently-connected farm is not in the owned set.
+  - [x] 2.3 Render already-connected foreign farms as removable chips (the combobox already renders selected values as removable); confirm removal + save works even when the foreign checkbox is toggled off.
+  - [x] 2.4 Add coverage: editing an owned-only depot → checkbox unchecked, owned-only options; editing a depot with a foreign connection → checkbox pre-enabled, foreign farm shown as removable chip, removal persists on save.
 
 - [x] 3. Farm-owner-scoped "managed by another account" notice (depends on: none) — model: fable
   - [x] 3.1 In `FarmDepotsSection.svelte`, gate the `details_depot_owned_by_other` branch on `isFarmOwner && !isOwned` (currently shows on any non-owned depot regardless of farm ownership).


### PR DESCRIPTION
## Summary
- Edit-mode depot editor now mirrors create mode: the loader (`routes/depots/[id]/edit/+page.ts`) supplies owned-farm options (`getMyEntries`) separately from all-farm options, replacing the previous unrestricted `getEntries`-only behavior.
- The foreign-farm checkbox in `DepotEditor.svelte` now also renders in edit mode and auto-enables on load when the depot already has a foreign-farm connection; already-connected foreign farms remain visible as removable chips regardless of checkbox state.
- Implements Feature 2 of `specs/depot-handling-improvements/spec.md`; plan checkboxes updated accordingly.

## Test plan
- [x] `svelte-check` (0 errors)
- [x] `playwright test e2e/depot-crud.test.ts` — all 6 tests pass, including 2 new tests covering owned-only edit (checkbox unchecked, foreign farm hidden) and foreign-connected edit (checkbox pre-enabled, chip removable, removal persists on save)