### PR TITLE
feat(map-next): Improve map icon highlights

### DIFF
--- a/packages/map-next/e2e/network-visualization.test.ts
+++ b/packages/map-next/e2e/network-visualization.test.ts
@@ -135,12 +135,12 @@ test('opening a farm profile with depots highlights its network and closing remo
 	await expect.poll(() => page.url(), { timeout: 15000 }).toContain('#/farms/farm-a');
 
 	// Network active: the farm's marker is highlighted (shared with the network layer).
-	await expect(page.locator('.marker-icon--network').first()).toBeVisible({ timeout: 15000 });
+	await expect(page.locator('.marker-button--highlighted').first()).toBeVisible({ timeout: 15000 });
 
 	await page.getByTestId('entry-detail-close').click();
 
 	// Closing the profile removes the network and its highlight.
-	await expect(page.locator('.marker-icon--network')).toHaveCount(0, { timeout: 15000 });
+	await expect(page.locator('.marker-button--highlighted')).toHaveCount(0, { timeout: 15000 });
 });
 
 test('clicking a depot marker opens its farm and highlights the network', async ({ page }) => {
@@ -164,5 +164,5 @@ test('clicking a depot marker opens its farm and highlights the network', async 
 	await page.locator('.maplibregl-canvas').click();
 
 	await expect.poll(() => page.url(), { timeout: 15000 }).toContain('#/farms/farm-a');
-	await expect(page.locator('.marker-icon--network').first()).toBeVisible({ timeout: 15000 });
+	await expect(page.locator('.marker-button--highlighted').first()).toBeVisible({ timeout: 15000 });
 });

--- a/packages/map-next/src/lib/components/domain/map/EntryMarkerButton.svelte
+++ b/packages/map-next/src/lib/components/domain/map/EntryMarkerButton.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+	import type { EntryFeature } from '$lib/types/entries';
+	import { getPlaceIcon } from '$lib/utils/marker-icons';
+	import { entryHoverKey, hoveredEntry } from '$lib/stores/hovered-entry.svelte';
+	import { cn } from '$lib/utils/tailwind';
+
+	interface EntryMarkerButtonProps {
+		entry: EntryFeature;
+		onClick: () => void;
+		/** Entry ids to emphasize while a farm↔depot network is open (shared state). */
+		highlightedIds?: ReadonlySet<string>;
+		/** Hover key of the entry whose profile is open; its marker stays selected. */
+		selectedKey?: string | null;
+		/** Extra classes, e.g. for cluster-specific positioning. */
+		class?: string;
+	}
+
+	let {
+		entry,
+		onClick,
+		highlightedIds,
+		selectedKey,
+		class: className
+	}: EntryMarkerButtonProps = $props();
+
+	const type = $derived(entry.properties.type.toLowerCase());
+	const isNetworkHighlighted = $derived(highlightedIds?.has(entry.properties.id) ?? false);
+	const hoverKey = $derived(entryHoverKey(entry.properties));
+	const isHovered = $derived(hoveredEntry.key === hoverKey);
+	const isSelected = $derived(selectedKey != null && selectedKey === hoverKey);
+</script>
+
+<button
+	type="button"
+	onclick={onClick}
+	onmouseenter={() => hoveredEntry.setHover(entry.properties, 'map')}
+	onmouseleave={() => hoveredEntry.clear(entry.properties)}
+	class={cn(
+		'marker-button',
+		isNetworkHighlighted && 'marker-button--network',
+		isHovered && 'marker-button--highlighted',
+		isSelected && 'marker-button--selected',
+		className
+	)}
+>
+	<img class="marker-icon" src={getPlaceIcon(type)} alt={entry.properties.name || type} />
+</button>
+
+<style>
+	.marker-button {
+		position: relative;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 45px;
+		height: 45px;
+		cursor: pointer;
+		--marker-drop-shadow: drop-shadow(0 2px 5px var(--base-color-map-network));
+	}
+
+	.marker-icon {
+		position: relative;
+		width: 30px;
+		height: 30px;
+		transition:
+			transform 150ms ease,
+			filter 150ms ease;
+		transform-origin: bottom center;
+		filter: var(--marker-drop-shadow);
+	}
+
+	.marker-button--highlighted {
+		transform: scale(1.2);
+		filter: drop-shadow(0 2px 10px var(--base-color-map-network));
+	}
+
+	.marker-button--selected {
+		transform: scale(1.2);
+	}
+</style>

--- a/packages/map-next/src/lib/components/domain/map/EntryMarkerButton.svelte
+++ b/packages/map-next/src/lib/components/domain/map/EntryMarkerButton.svelte
@@ -55,7 +55,7 @@
 		width: 45px;
 		height: 45px;
 		cursor: pointer;
-		--marker-drop-shadow: drop-shadow(0 2px 5px var(--base-color-map-network));
+		--marker-drop-shadow: drop-shadow(0 2px 5px var(--map-network-line));
 	}
 
 	.marker-icon {
@@ -71,7 +71,7 @@
 
 	.marker-button--highlighted {
 		transform: scale(1.2);
-		filter: drop-shadow(0 2px 10px var(--base-color-map-network));
+		filter: drop-shadow(0 2px 10px var(--map-network-line));
 	}
 
 	.marker-button--selected {

--- a/packages/map-next/src/lib/components/domain/map/EntryMarkerButton.svelte
+++ b/packages/map-next/src/lib/components/domain/map/EntryMarkerButton.svelte
@@ -2,26 +2,17 @@
 	import type { EntryFeature } from '$lib/types/entries';
 	import { getPlaceIcon } from '$lib/utils/marker-icons';
 	import { entryHoverKey, hoveredEntry } from '$lib/stores/hovered-entry.svelte';
-	import { cn } from '$lib/utils/tailwind';
 
 	interface EntryMarkerButtonProps {
 		entry: EntryFeature;
 		onClick: () => void;
-		/** Entry ids to emphasize while a farm↔depot network is open (shared state). */
-		highlightedIds?: ReadonlySet<string>;
 		/** Hover key of the entry whose profile is open; its marker stays selected. */
 		selectedKey?: string | null;
 		/** Extra classes, e.g. for cluster-specific positioning. */
 		class?: string;
 	}
 
-	let {
-		entry,
-		onClick,
-		highlightedIds,
-		selectedKey,
-		class: className
-	}: EntryMarkerButtonProps = $props();
+	let { entry, onClick, selectedKey, class: className }: EntryMarkerButtonProps = $props();
 
 	const type = $derived(entry.properties.type.toLowerCase());
 	const hoverKey = $derived(entryHoverKey(entry.properties));
@@ -34,12 +25,8 @@
 	onclick={onClick}
 	onmouseenter={() => hoveredEntry.setHover(entry.properties, 'map')}
 	onmouseleave={() => hoveredEntry.clear(entry.properties)}
-	class={cn(
-		'marker-button',
-		isHovered && 'marker-button--highlighted',
-		isSelected && 'marker-button--selected',
-		className
-	)}
+	class={['marker-button', className]}
+	class:marker-button--highlighted={isHovered || isSelected}
 >
 	<img class="marker-icon" src={getPlaceIcon(type)} alt={entry.properties.name || type} />
 </button>
@@ -70,9 +57,5 @@
 	.marker-button--highlighted {
 		transform: scale(1.2);
 		filter: drop-shadow(0 2px 10px var(--map-network-line));
-	}
-
-	.marker-button--selected {
-		transform: scale(1.2);
 	}
 </style>

--- a/packages/map-next/src/lib/components/domain/map/EntryMarkerButton.svelte
+++ b/packages/map-next/src/lib/components/domain/map/EntryMarkerButton.svelte
@@ -24,7 +24,6 @@
 	}: EntryMarkerButtonProps = $props();
 
 	const type = $derived(entry.properties.type.toLowerCase());
-	const isNetworkHighlighted = $derived(highlightedIds?.has(entry.properties.id) ?? false);
 	const hoverKey = $derived(entryHoverKey(entry.properties));
 	const isHovered = $derived(hoveredEntry.key === hoverKey);
 	const isSelected = $derived(selectedKey != null && selectedKey === hoverKey);
@@ -37,7 +36,6 @@
 	onmouseleave={() => hoveredEntry.clear(entry.properties)}
 	class={cn(
 		'marker-button',
-		isNetworkHighlighted && 'marker-button--network',
 		isHovered && 'marker-button--highlighted',
 		isSelected && 'marker-button--selected',
 		className

--- a/packages/map-next/src/lib/components/domain/map/EntryMarkerButton.svelte
+++ b/packages/map-next/src/lib/components/domain/map/EntryMarkerButton.svelte
@@ -6,17 +6,26 @@
 	interface EntryMarkerButtonProps {
 		entry: EntryFeature;
 		onClick: () => void;
+		/** Entry ids to emphasize while a farm↔depot network is open (shared state). */
+		highlightedIds?: ReadonlySet<string>;
 		/** Hover key of the entry whose profile is open; its marker stays selected. */
 		selectedKey?: string | null;
 		/** Extra classes, e.g. for cluster-specific positioning. */
 		class?: string;
 	}
 
-	let { entry, onClick, selectedKey, class: className }: EntryMarkerButtonProps = $props();
+	let {
+		entry,
+		onClick,
+		highlightedIds,
+		selectedKey,
+		class: className
+	}: EntryMarkerButtonProps = $props();
 
 	const type = $derived(entry.properties.type.toLowerCase());
 	const hoverKey = $derived(entryHoverKey(entry.properties));
 	const isHovered = $derived(hoveredEntry.key === hoverKey);
+	const isHighlighted = $derived(highlightedIds?.has(entry.properties.id) ?? false);
 	const isSelected = $derived(selectedKey != null && selectedKey === hoverKey);
 </script>
 
@@ -26,7 +35,8 @@
 	onmouseenter={() => hoveredEntry.setHover(entry.properties, 'map')}
 	onmouseleave={() => hoveredEntry.clear(entry.properties)}
 	class={['marker-button', className]}
-	class:marker-button--highlighted={isHovered || isSelected}
+	class:marker-button--highlighted={isHovered || isHighlighted}
+	class:marker-button--selected={isSelected}
 >
 	<img class="marker-icon" src={getPlaceIcon(type)} alt={entry.properties.name || type} />
 </button>
@@ -57,5 +67,9 @@
 	.marker-button--highlighted {
 		transform: scale(1.2);
 		filter: drop-shadow(0 2px 10px var(--map-network-line));
+	}
+
+	.marker-button--selected {
+		transform: scale(1.2);
 	}
 </style>

--- a/packages/map-next/src/lib/components/domain/map/NetworkLayer.svelte
+++ b/packages/map-next/src/lib/components/domain/map/NetworkLayer.svelte
@@ -44,25 +44,29 @@
 		)
 	});
 
-	// Highlight rings around every involved marker (farm + each depot).
+	// Highlight rings around every involved depot marker.
 	const highlightData = $derived<FeatureCollection<Point>>({
+		type: 'FeatureCollection',
+		features: depots.map(
+			(depot): Feature<Point> => ({
+				type: 'Feature',
+				properties: {
+					role: 'depot',
+					selected: depot.properties.id === effectiveSelectedId
+				},
+				geometry: { type: 'Point', coordinates: depot.geometry.coordinates }
+			})
+		)
+	});
+
+	const farmCenterData = $derived<FeatureCollection<Point>>({
 		type: 'FeatureCollection',
 		features: [
 			{
 				type: 'Feature',
 				properties: { role: 'farm', selected: false },
 				geometry: { type: 'Point', coordinates: farmCoordinates }
-			},
-			...depots.map(
-				(depot): Feature<Point> => ({
-					type: 'Feature',
-					properties: {
-						role: 'depot',
-						selected: depot.properties.id === effectiveSelectedId
-					},
-					geometry: { type: 'Point', coordinates: depot.geometry.coordinates }
-				})
-			)
+			}
 		]
 	});
 </script>
@@ -71,7 +75,7 @@
 	<GeoJSON id="farm-network-lines" data={lineData}>
 		<LineLayer
 			id="farm-network-line"
-			beforeId="label-boundary-state"
+			beforeId="primary-clusters"
 			layout={{ 'line-cap': 'round', 'line-join': 'round' }}
 			paint={{
 				'line-color': theme.networkLineColor,
@@ -90,14 +94,26 @@
 	<GeoJSON id="farm-network-highlights" data={highlightData}>
 		<CircleLayer
 			id="farm-network-highlight"
-			beforeId="label-boundary-state"
+			beforeId="primary-clusters"
 			paint={{
 				'circle-radius': ['case', ['get', 'selected'], 18, 13],
 				'circle-color': theme.networkLineColor,
-				'circle-opacity': ['case', ['get', 'selected'], 0.22, 0.12],
-				'circle-stroke-color': theme.networkLineColor,
-				'circle-stroke-width': ['case', ['get', 'selected'], 3, 2],
-				'circle-stroke-opacity': ['case', ['get', 'selected'], 0.95, 0.7]
+				'circle-opacity': 0.9,
+				'circle-pitch-alignment': 'map'
+			}}
+			interactive={false}
+		/>
+	</GeoJSON>
+
+	<GeoJSON id="farm-network-farm-highlight" data={farmCenterData}>
+		<CircleLayer
+			id="farm-network-farm-highlight"
+			beforeId="primary-clusters"
+			paint={{
+				'circle-radius': 35,
+				'circle-color': theme.networkLineColor,
+				'circle-opacity': 0.9,
+				'circle-pitch-alignment': 'map'
 			}}
 			interactive={false}
 		/>

--- a/packages/map-next/src/lib/components/domain/map/NetworkLayer.svelte
+++ b/packages/map-next/src/lib/components/domain/map/NetworkLayer.svelte
@@ -4,6 +4,9 @@
 	import type { FarmFeature } from '$lib/types/entries';
 	import type { MapDesignTokens } from '$lib/design/themes';
 
+	// Move the network layers below the boundary state layer, so that they are nicely set in the background.
+	const BEFORE_ID = 'boundary-state';
+
 	interface NetworkLayerProps {
 		/** The open farm whose depot network should be drawn. */
 		farm: FarmFeature;
@@ -75,7 +78,7 @@
 	<GeoJSON id="farm-network-lines" data={lineData}>
 		<LineLayer
 			id="farm-network-line"
-			beforeId="primary-clusters"
+			beforeId={BEFORE_ID}
 			layout={{ 'line-cap': 'round', 'line-join': 'round' }}
 			paint={{
 				'line-color': theme.networkLineColor,
@@ -94,7 +97,7 @@
 	<GeoJSON id="farm-network-highlights" data={highlightData}>
 		<CircleLayer
 			id="farm-network-highlight"
-			beforeId="primary-clusters"
+			beforeId={BEFORE_ID}
 			paint={{
 				'circle-radius': ['case', ['get', 'selected'], 18, 13],
 				'circle-color': theme.networkLineColor,
@@ -108,7 +111,7 @@
 	<GeoJSON id="farm-network-farm-highlight" data={farmCenterData}>
 		<CircleLayer
 			id="farm-network-farm-highlight"
-			beforeId="primary-clusters"
+			beforeId={BEFORE_ID}
 			paint={{
 				'circle-radius': 35,
 				'circle-color': theme.networkLineColor,

--- a/packages/map-next/src/lib/components/domain/map/NetworkLayer.svelte
+++ b/packages/map-next/src/lib/components/domain/map/NetworkLayer.svelte
@@ -1,23 +1,26 @@
 <script lang="ts">
 	import { GeoJSON, LineLayer, CircleLayer } from 'svelte-maplibre';
 	import type { Feature, FeatureCollection, LineString, Point } from 'geojson';
-	import type { FarmFeature } from '$lib/types/entries';
+	import type { MainEntryFeature } from '$lib/types/entries';
 	import type { MapDesignTokens } from '$lib/design/themes';
 
 	// Move the network layers below the boundary state layer, so that they are nicely set in the background.
 	const BEFORE_ID = 'boundary-state';
 
 	interface NetworkLayerProps {
-		/** The open farm whose depot network should be drawn. */
-		farm: FarmFeature;
+		/** The open farm or initiative whose network (and highlight) should be drawn. */
+		entry: MainEntryFeature;
 		/** Depot to emphasize (e.g. the one the user selected to reach this farm). */
 		selectedDepotId?: string | null;
 		theme: MapDesignTokens;
 	}
 
-	let { farm, selectedDepotId = null, theme }: NetworkLayerProps = $props();
+	let { entry, selectedDepotId = null, theme }: NetworkLayerProps = $props();
 
-	const depots = $derived(farm.properties.depots?.features ?? []);
+	// Only farms have a depot network; initiatives just get the entry highlight below.
+	const depots = $derived(
+		entry.properties.type === 'Farm' ? (entry.properties.depots?.features ?? []) : []
+	);
 
 	// Only honour a selection that actually belongs to this farm's depots, so a
 	// stale id left over from a previously opened farm is ignored.
@@ -27,7 +30,7 @@
 			: null
 	);
 
-	const farmCoordinates = $derived(farm.geometry.coordinates);
+	const entryCoordinates = $derived(entry.geometry.coordinates);
 
 	// One LineString per depot, farm → depot.
 	const lineData = $derived<FeatureCollection<LineString>>({
@@ -41,7 +44,7 @@
 				},
 				geometry: {
 					type: 'LineString',
-					coordinates: [farmCoordinates, depot.geometry.coordinates]
+					coordinates: [entryCoordinates, depot.geometry.coordinates]
 				}
 			})
 		)
@@ -62,63 +65,61 @@
 		)
 	});
 
-	const farmCenterData = $derived<FeatureCollection<Point>>({
+	const entryCenterData = $derived<FeatureCollection<Point>>({
 		type: 'FeatureCollection',
 		features: [
 			{
 				type: 'Feature',
-				properties: { role: 'farm', selected: false },
-				geometry: { type: 'Point', coordinates: farmCoordinates }
+				properties: { role: entry.properties.type.toLowerCase(), selected: false },
+				geometry: { type: 'Point', coordinates: entryCoordinates }
 			}
 		]
 	});
 </script>
 
-{#if depots.length > 0}
-	<GeoJSON id="farm-network-lines" data={lineData}>
-		<LineLayer
-			id="farm-network-line"
-			beforeId={BEFORE_ID}
-			layout={{ 'line-cap': 'round', 'line-join': 'round' }}
-			paint={{
-				'line-color': theme.networkLineColor,
-				'line-width': [
-					'case',
-					['get', 'selected'],
-					theme.networkLineWidth + 2,
-					theme.networkLineWidth
-				],
-				'line-opacity': ['case', ['get', 'selected'], 0.95, 0.6]
-			}}
-			interactive={false}
-		/>
-	</GeoJSON>
+<GeoJSON id="farm-network-lines" data={lineData}>
+	<LineLayer
+		id="farm-network-line"
+		beforeId={BEFORE_ID}
+		layout={{ 'line-cap': 'round', 'line-join': 'round' }}
+		paint={{
+			'line-color': theme.networkLineColor,
+			'line-width': [
+				'case',
+				['get', 'selected'],
+				theme.networkLineWidth + 2,
+				theme.networkLineWidth
+			],
+			'line-opacity': ['case', ['get', 'selected'], 0.95, 0.6]
+		}}
+		interactive={false}
+	/>
+</GeoJSON>
 
-	<GeoJSON id="farm-network-highlights" data={highlightData}>
-		<CircleLayer
-			id="farm-network-highlight"
-			beforeId={BEFORE_ID}
-			paint={{
-				'circle-radius': ['case', ['get', 'selected'], 18, 13],
-				'circle-color': theme.networkLineColor,
-				'circle-opacity': 0.9,
-				'circle-pitch-alignment': 'map'
-			}}
-			interactive={false}
-		/>
-	</GeoJSON>
+<GeoJSON id="farm-network-highlights" data={highlightData}>
+	<CircleLayer
+		id="farm-network-highlight"
+		beforeId={BEFORE_ID}
+		paint={{
+			'circle-radius': ['case', ['get', 'selected'], 18, 13],
+			'circle-color': theme.networkLineColor,
+			'circle-opacity': 0.9,
+			'circle-pitch-alignment': 'map'
+		}}
+		interactive={false}
+	/>
+</GeoJSON>
 
-	<GeoJSON id="farm-network-farm-highlight" data={farmCenterData}>
-		<CircleLayer
-			id="farm-network-farm-highlight"
-			beforeId={BEFORE_ID}
-			paint={{
-				'circle-radius': 35,
-				'circle-color': theme.networkLineColor,
-				'circle-opacity': 0.9,
-				'circle-pitch-alignment': 'map'
-			}}
-			interactive={false}
-		/>
-	</GeoJSON>
-{/if}
+<GeoJSON id="farm-network-farm-highlight" data={entryCenterData}>
+	<CircleLayer
+		id="farm-network-farm-highlight"
+		beforeId={BEFORE_ID}
+		paint={{
+			'circle-radius': 35,
+			'circle-color': theme.networkLineColor,
+			'circle-opacity': 0.9,
+			'circle-pitch-alignment': 'map'
+		}}
+		interactive={false}
+	/>
+</GeoJSON>

--- a/packages/map-next/src/lib/components/domain/map/SymbolMarkerCluster.svelte
+++ b/packages/map-next/src/lib/components/domain/map/SymbolMarkerCluster.svelte
@@ -92,7 +92,6 @@
 
 <div class="cluster-container" style="--backdrop-size: {backdropSize}px">
 	{#if iconCount > 0}
-		<div class="cluster-backdrop"></div>
 		{#each clusterFeatures.slice(0, MAX_ICONS) as clusterFeature, i (clusterFeature.properties.id)}
 			{@const type = clusterFeature.properties?.type?.toLowerCase()}
 			{@const icon = getPlaceIcon(type)}
@@ -109,11 +108,6 @@
 				/>
 			</button>
 		{/each}
-		{#if pointCount > 1}
-			<span class="cluster-count">
-				{pointCountLabel}
-			</span>
-		{/if}
 	{/if}
 </div>
 
@@ -125,20 +119,6 @@
 		justify-content: center;
 		width: 100px;
 		height: 100px;
-	}
-
-	/* Translucent deep-green disc sitting behind the grouped type icons. */
-	.cluster-backdrop {
-		position: absolute;
-		left: 50%;
-		top: 50%;
-		width: var(--backdrop-size);
-		height: var(--backdrop-size);
-		margin-left: calc(var(--backdrop-size) / -2);
-		margin-top: calc(var(--backdrop-size) / -2);
-		border-radius: 9999px;
-		background: var(--map-cluster-circle);
-		pointer-events: none;
 	}
 
 	.cluster-icon-button {
@@ -156,31 +136,6 @@
 		width: 30px;
 		height: 30px;
 		cursor: pointer;
-	}
-
-	/*
-	 * Coral count badge pinned to the top-right edge of the backdrop disc.
-	 * 0.354 ≈ cos(45°)/2 (= 1/(2√2)): projects the disc radius (--backdrop-size / 2)
-	 * onto the x/y axes to land the badge centre on the 45° edge of the circle.
-	 */
-	.cluster-count {
-		position: absolute;
-		left: calc(50% + var(--backdrop-size) * 0.354);
-		top: calc(50% - var(--backdrop-size) * 0.354);
-		transform: translate(-50%, -50%);
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		min-width: 18px;
-		height: 18px;
-		padding: 0 5px;
-		border-radius: 9999px;
-		background: var(--map-cluster-count);
-		color: var(--background);
-		font-family: var(--map-font-bold);
-		font-size: 11px;
-		line-height: 1;
-		font-weight: 700;
-		pointer-events: none;
+		filter: drop-shadow(0 0 5px var(--map-base));
 	}
 </style>

--- a/packages/map-next/src/lib/components/domain/map/SymbolMarkerCluster.svelte
+++ b/packages/map-next/src/lib/components/domain/map/SymbolMarkerCluster.svelte
@@ -105,6 +105,7 @@
 				<EntryMarkerButton
 					entry={clusterFeature}
 					onClick={() => onMarkerClick(clusterFeature, { offset: [position.x, position.y] })}
+					{highlightedIds}
 					{selectedKey}
 				/>
 			</div>

--- a/packages/map-next/src/lib/components/domain/map/SymbolMarkerCluster.svelte
+++ b/packages/map-next/src/lib/components/domain/map/SymbolMarkerCluster.svelte
@@ -3,15 +3,19 @@
 	import type { Feature, GeoJsonProperties, Geometry } from 'geojson';
 	import type { EntryFeature } from '$lib/types/entries';
 	import type { GeoJSONSource } from 'maplibre-gl';
-	import { getPlaceIcon } from '$lib/utils/marker-icons';
+	import EntryMarkerButton from './EntryMarkerButton.svelte';
 
 	interface ClusterMarkerProps {
 		// Cluster features arrive untyped from svelte-maplibre; we only read `cluster_id`.
 		feature: Feature<Geometry, GeoJsonProperties>;
 		onMarkerClick: (feature: EntryFeature, options?: { offset?: [number, number] }) => void;
+		/** Entry ids to emphasize while a farm↔depot network is open (shared state). */
+		highlightedIds?: ReadonlySet<string>;
+		/** Hover key of the entry whose profile is open; its marker stays selected. */
+		selectedKey?: string | null;
 	}
 
-	let { feature, onMarkerClick }: ClusterMarkerProps = $props();
+	let { feature, onMarkerClick, highlightedIds, selectedKey }: ClusterMarkerProps = $props();
 
 	const mapContext = getMapContext();
 	const map = $derived(mapContext.map);
@@ -93,20 +97,18 @@
 <div class="cluster-container" style="--backdrop-size: {backdropSize}px">
 	{#if iconCount > 0}
 		{#each clusterFeatures.slice(0, MAX_ICONS) as clusterFeature, i (clusterFeature.properties.id)}
-			{@const type = clusterFeature.properties?.type?.toLowerCase()}
-			{@const icon = getPlaceIcon(type)}
 			{@const position = getCirclePosition(i, iconCount)}
-			<button
-				onclick={() => onMarkerClick(clusterFeature, { offset: [position.x, position.y] })}
-				class="cluster-icon-button"
+			<div
+				class="cluster-icon-position"
+				style="transform: translate({position.x}px, {position.y}px)"
 			>
-				<img
-					src={icon}
-					class="marker-icon"
-					alt={clusterFeature.properties?.name || type}
-					style="transform: translate({position.x}px, {position.y}px)"
+				<EntryMarkerButton
+					entry={clusterFeature}
+					onClick={() => onMarkerClick(clusterFeature, { offset: [position.x, position.y] })}
+					{highlightedIds}
+					{selectedKey}
 				/>
-			</button>
+			</div>
 		{/each}
 	{/if}
 </div>
@@ -121,21 +123,11 @@
 		height: 100px;
 	}
 
-	.cluster-icon-button {
+	.cluster-icon-position {
 		position: absolute;
-		width: 30px;
-		height: 30px;
 		left: 50%;
 		top: 50%;
-		margin-left: -15px;
-		margin-top: -15px;
-		cursor: pointer;
-	}
-
-	.marker-icon {
-		width: 30px;
-		height: 30px;
-		cursor: pointer;
-		filter: drop-shadow(0 0 5px var(--map-base));
+		margin-left: -22.5px;
+		margin-top: -22.5px;
 	}
 </style>

--- a/packages/map-next/src/lib/components/domain/map/SymbolMarkerCluster.svelte
+++ b/packages/map-next/src/lib/components/domain/map/SymbolMarkerCluster.svelte
@@ -105,7 +105,6 @@
 				<EntryMarkerButton
 					entry={clusterFeature}
 					onClick={() => onMarkerClick(clusterFeature, { offset: [position.x, position.y] })}
-					{highlightedIds}
 					{selectedKey}
 				/>
 			</div>

--- a/packages/map-next/src/lib/components/domain/map/SymbolMarkerLayer.svelte
+++ b/packages/map-next/src/lib/components/domain/map/SymbolMarkerLayer.svelte
@@ -66,16 +66,6 @@
 		--marker-drop-shadow: drop-shadow(0 2px 5px var(--base-color-map-network));
 	}
 
-	.marker-button--selected::before {
-		content: '';
-		position: absolute;
-		width: 50px;
-		height: 50px;
-		border-radius: 50%;
-		background-color: var(--base-color-map-network);
-		opacity: 0.5;
-	}
-
 	.marker-icon {
 		position: relative;
 		width: 30px;

--- a/packages/map-next/src/lib/components/domain/map/SymbolMarkerLayer.svelte
+++ b/packages/map-next/src/lib/components/domain/map/SymbolMarkerLayer.svelte
@@ -29,7 +29,12 @@
 	{#snippet children({ feature })}
 		{@const entry = asEntryFeature(feature)}
 		{#if entry}
-			<EntryMarkerButton {entry} onClick={() => onMarkerClick(entry)} {selectedKey} />
+			<EntryMarkerButton
+				{entry}
+				onClick={() => onMarkerClick(entry)}
+				{highlightedIds}
+				{selectedKey}
+			/>
 		{/if}
 	{/snippet}
 </MarkerLayer>

--- a/packages/map-next/src/lib/components/domain/map/SymbolMarkerLayer.svelte
+++ b/packages/map-next/src/lib/components/domain/map/SymbolMarkerLayer.svelte
@@ -41,51 +41,58 @@
 				onclick={() => onMarkerClick(entry)}
 				onmouseenter={() => hoveredEntry.setHover(entry.properties, 'map')}
 				onmouseleave={() => hoveredEntry.clear(entry.properties)}
+				class={cn(
+					'marker-button',
+					isNetworkHighlighted && 'marker-button--network',
+					isHovered && 'marker-button--highlighted',
+					isSelected && 'marker-button--selected'
+				)}
 			>
-				<img
-					class={cn(
-						'marker-icon',
-						isNetworkHighlighted && 'marker-icon--network',
-						isHovered && 'marker-icon--highlighted',
-						isSelected && 'marker-icon--selected'
-					)}
-					src={getPlaceIcon(type)}
-					alt={entry.properties.name || type}
-				/>
+				<img class="marker-icon" src={getPlaceIcon(type)} alt={entry.properties.name || type} />
 			</button>
 		{/if}
 	{/snippet}
 </MarkerLayer>
 
 <style>
+	.marker-button {
+		position: relative;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 45px;
+		height: 45px;
+		cursor: pointer;
+		--marker-drop-shadow: drop-shadow(0 2px 5px var(--base-color-map-network));
+	}
+
+	.marker-button--selected::before {
+		content: '';
+		position: absolute;
+		width: 50px;
+		height: 50px;
+		border-radius: 50%;
+		background-color: var(--base-color-map-network);
+		opacity: 0.5;
+	}
+
 	.marker-icon {
+		position: relative;
 		width: 30px;
 		height: 30px;
-		cursor: pointer;
 		transition:
 			transform 150ms ease,
 			filter 150ms ease;
 		transform-origin: bottom center;
+		filter: var(--marker-drop-shadow);
 	}
 
-	.marker-icon--highlighted {
+	.marker-button--highlighted {
 		transform: scale(1.3);
-		filter: drop-shadow(0 2px 4px color-mix(in srgb, var(--foreground) 35%, transparent));
+		filter: drop-shadow(0 2px 10px var(--base-color-map-network));
 	}
 
-	.marker-icon--network {
-		transform: scale(1.25);
-		filter: drop-shadow(0 0 4px var(--map-network-line));
-	}
-
-	/*
-	 * Selected marker: the entry whose profile is open. Scales up and gains a
-	 * salmon glow so it stays distinct until the profile closes. Takes precedence
-	 * over hover/network so an open profile always reads as the selected place.
-	 */
-	.marker-icon--selected {
-		transform: scale(1.45);
-		filter: drop-shadow(0 0 3px var(--map-marker-selected))
-			drop-shadow(0 2px 5px color-mix(in srgb, var(--foreground) 40%, transparent));
+	.marker-button--selected {
+		transform: scale(1.3);
 	}
 </style>

--- a/packages/map-next/src/lib/components/domain/map/SymbolMarkerLayer.svelte
+++ b/packages/map-next/src/lib/components/domain/map/SymbolMarkerLayer.svelte
@@ -2,9 +2,7 @@
 	import { MarkerLayer } from 'svelte-maplibre';
 	import type { EntryFeature } from '$lib/types/entries';
 	import { asEntryFeature } from '$lib/utils/entry-features';
-	import { getPlaceIcon } from '$lib/utils/marker-icons';
-	import { entryHoverKey, hoveredEntry } from '$lib/stores/hovered-entry.svelte';
-	import { cn } from '$lib/utils/tailwind';
+	import EntryMarkerButton from './EntryMarkerButton.svelte';
 	import SymbolMarkerCluster from './SymbolMarkerCluster.svelte';
 
 	interface SymbolMarkerLayerProps {
@@ -22,7 +20,7 @@
 <!-- Cluster markers -->
 <MarkerLayer applyToClusters {minzoom}>
 	{#snippet children({ feature })}
-		<SymbolMarkerCluster {feature} {onMarkerClick} />
+		<SymbolMarkerCluster {feature} {onMarkerClick} {highlightedIds} {selectedKey} />
 	{/snippet}
 </MarkerLayer>
 
@@ -31,58 +29,12 @@
 	{#snippet children({ feature })}
 		{@const entry = asEntryFeature(feature)}
 		{#if entry}
-			{@const type = entry.properties.type.toLowerCase()}
-			{@const isNetworkHighlighted = highlightedIds?.has(entry.properties.id) ?? false}
-			{@const hoverKey = entryHoverKey(entry.properties)}
-			{@const isHovered = hoveredEntry.key === hoverKey}
-			{@const isSelected = selectedKey != null && selectedKey === hoverKey}
-			<button
-				type="button"
-				onclick={() => onMarkerClick(entry)}
-				onmouseenter={() => hoveredEntry.setHover(entry.properties, 'map')}
-				onmouseleave={() => hoveredEntry.clear(entry.properties)}
-				class={cn(
-					'marker-button',
-					isNetworkHighlighted && 'marker-button--network',
-					isHovered && 'marker-button--highlighted',
-					isSelected && 'marker-button--selected'
-				)}
-			>
-				<img class="marker-icon" src={getPlaceIcon(type)} alt={entry.properties.name || type} />
-			</button>
+			<EntryMarkerButton
+				{entry}
+				onClick={() => onMarkerClick(entry)}
+				{highlightedIds}
+				{selectedKey}
+			/>
 		{/if}
 	{/snippet}
 </MarkerLayer>
-
-<style>
-	.marker-button {
-		position: relative;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		width: 45px;
-		height: 45px;
-		cursor: pointer;
-		--marker-drop-shadow: drop-shadow(0 2px 5px var(--base-color-map-network));
-	}
-
-	.marker-icon {
-		position: relative;
-		width: 30px;
-		height: 30px;
-		transition:
-			transform 150ms ease,
-			filter 150ms ease;
-		transform-origin: bottom center;
-		filter: var(--marker-drop-shadow);
-	}
-
-	.marker-button--highlighted {
-		transform: scale(1.3);
-		filter: drop-shadow(0 2px 10px var(--base-color-map-network));
-	}
-
-	.marker-button--selected {
-		transform: scale(1.3);
-	}
-</style>

--- a/packages/map-next/src/lib/components/domain/map/SymbolMarkerLayer.svelte
+++ b/packages/map-next/src/lib/components/domain/map/SymbolMarkerLayer.svelte
@@ -29,12 +29,7 @@
 	{#snippet children({ feature })}
 		{@const entry = asEntryFeature(feature)}
 		{#if entry}
-			<EntryMarkerButton
-				{entry}
-				onClick={() => onMarkerClick(entry)}
-				{highlightedIds}
-				{selectedKey}
-			/>
+			<EntryMarkerButton {entry} onClick={() => onMarkerClick(entry)} {selectedKey} />
 		{/if}
 	{/snippet}
 </MarkerLayer>

--- a/packages/map-next/src/lib/design/theme-vars.css
+++ b/packages/map-next/src/lib/design/theme-vars.css
@@ -51,7 +51,7 @@
 	--base-color-map-place: #ffc8af;
 	--base-color-map-cluster: #ffa08c;
 	--base-color-map-cluster-count: #f4695b;
-	--base-color-map-network: color-mix(in srgb, var(--map-base) 70%, black);
+	--base-color-map-network: #1f4e42;
 
 	/* typography */
 	--font-family-sans: var(--base-font-inter);

--- a/packages/map-next/src/lib/design/theme-vars.css
+++ b/packages/map-next/src/lib/design/theme-vars.css
@@ -51,7 +51,7 @@
 	--base-color-map-place: #ffc8af;
 	--base-color-map-cluster: #ffa08c;
 	--base-color-map-cluster-count: #f4695b;
-	--base-color-map-network: #266050;
+	--base-color-map-network: color-mix(in srgb, var(--map-base) 70%, black);
 
 	/* typography */
 	--font-family-sans: var(--base-font-inter);

--- a/packages/map-next/src/routes/Map.svelte
+++ b/packages/map-next/src/routes/Map.svelte
@@ -14,7 +14,12 @@
 	import { getMapStyle } from '$lib/design/map-style';
 	import config from '$lib/config/app-configuration';
 	import { readMapDesignTokens, type MapDesignTokens } from '$lib/design/themes';
-	import type { EntryFeature, EntryFeatureCollection, FarmFeature } from '$lib/types/entries';
+	import type {
+		EntryFeature,
+		EntryFeatureCollection,
+		FarmFeature,
+		MainEntryFeature
+	} from '$lib/types/entries';
 	import type { DiscoveryFocus } from '$lib/types/discovery';
 	import 'maplibre-gl/dist/maplibre-gl.css';
 	import { AccountTokenHandler, UserNavigation } from '$lib/components/layout';
@@ -133,15 +138,20 @@
 	const discoveryFocus = $derived(page.data.discoveryFocus);
 	const myEntriesStore = createMyEntriesStore();
 
-	// Farm↔depot network: only render for an open farm profile that has depots
-	// (never for initiatives or depot-less farms).
+	// Farm/initiative network: rendered for any open main-entry profile, so the
+	// entry itself is highlighted; a farm's depot lines/highlights additionally
+	// appear when it has depots.
 	const detailData = $derived(page.data.detailData);
-	const networkFarm = $derived.by<FarmFeature | null>(() => {
+	const networkEntry = $derived<MainEntryFeature | null>(detailData ?? null);
+	// The subset of the above that's a farm with depots, used to drive the
+	// network fitBounds camera (initiatives and depot-less farms have no network
+	// to fit, so they fall back to the plain focusEntry flyTo instead).
+	const networkFarmWithDepots = $derived.by<FarmFeature | null>(() => {
 		if (
-			detailData?.properties.type === 'Farm' &&
-			(detailData.properties.depots?.features?.length ?? 0) > 0
+			networkEntry?.properties.type === 'Farm' &&
+			(networkEntry.properties.depots?.features?.length ?? 0) > 0
 		) {
-			return detailData as FarmFeature;
+			return networkEntry as FarmFeature;
 		}
 		return null;
 	});
@@ -150,9 +160,9 @@
 	const selectedEntryKey = $derived(detailData ? entryHoverKey(detailData.properties) : null);
 	const highlightedNetworkIds = $derived.by<SvelteSet<string>>(() => {
 		const ids = new SvelteSet<string>();
-		if (networkFarm) {
-			ids.add(networkFarm.properties.id);
-			for (const depot of networkFarm.properties.depots?.features ?? []) {
+		if (networkEntry) {
+			ids.add(networkEntry.properties.id);
+			for (const depot of networkFarmWithDepots?.properties.depots?.features ?? []) {
 				ids.add(depot.properties.id);
 			}
 		}
@@ -160,21 +170,23 @@
 	});
 
 	// Fit the viewport to the whole network when a farm profile with depots opens.
+	// Depot-less farms and initiatives are framed by the plain focusEntry flyTo
+	// instead (see featureIsNetworkFarm), so there's nothing to fit here for them.
 	let lastNetworkFitFarmId = $state<string | null>(null);
 	$effect(() => {
-		if (!map || !networkFarm) {
+		if (!map || !networkFarmWithDepots) {
 			lastNetworkFitFarmId = null;
 			return;
 		}
 
-		if (networkFarm.properties.id === lastNetworkFitFarmId) {
+		if (networkFarmWithDepots.properties.id === lastNetworkFitFarmId) {
 			return;
 		}
-		lastNetworkFitFarmId = networkFarm.properties.id;
+		lastNetworkFitFarmId = networkFarmWithDepots.properties.id;
 
 		const bounds = new LngLatBounds();
-		bounds.extend(networkFarm.geometry.coordinates as [number, number]);
-		for (const depot of networkFarm.properties.depots?.features ?? []) {
+		bounds.extend(networkFarmWithDepots.geometry.coordinates as [number, number]);
+		for (const depot of networkFarmWithDepots.properties.depots?.features ?? []) {
 			bounds.extend(depot.geometry.coordinates as [number, number]);
 		}
 
@@ -622,10 +634,10 @@
 			<NavigationControl position={mapControlsPosition} />
 			<GeolocateControl position={mapControlsPosition} />
 
-			<!-- Farm↔depot network visualization for the open farm profile -->
-			{#if networkFarm}
+			<!-- Farm/initiative network visualization for the open profile -->
+			{#if networkEntry}
 				<NetworkLayer
-					farm={networkFarm}
+					entry={networkEntry}
 					selectedDepotId={networkSelection.selectedDepotId}
 					theme={mapTheme}
 				/>

--- a/packages/map-next/src/routes/Map.svelte
+++ b/packages/map-next/src/routes/Map.svelte
@@ -622,6 +622,15 @@
 			<NavigationControl position={mapControlsPosition} />
 			<GeolocateControl position={mapControlsPosition} />
 
+			<!-- Farm↔depot network visualization for the open farm profile -->
+			{#if networkFarm}
+				<NetworkLayer
+					farm={networkFarm}
+					selectedDepotId={networkSelection.selectedDepotId}
+					theme={mapTheme}
+				/>
+			{/if}
+
 			<GeoJSON
 				id="secondary-places"
 				data={secondaryPlaces}
@@ -675,15 +684,6 @@
 					selectedKey={selectedEntryKey}
 				/>
 			</GeoJSON>
-
-			<!-- Farm↔depot network visualization for the open farm profile -->
-			{#if networkFarm}
-				<NetworkLayer
-					farm={networkFarm}
-					selectedDepotId={networkSelection.selectedDepotId}
-					theme={mapTheme}
-				/>
-			{/if}
 
 			<!-- Programmatic popup for selected entry from sidebar -->
 			{#if selectedEntry}


### PR DESCRIPTION
- Consistent design for marker icons (highlight, selected)
- Consistent design for network layer

**TODO:**
- [x] Always place network layer below icons (order swaps at redraw)
- [x] Reduce code duplication (`SymbolMarkerLayer`, `SymbolMarkerCluster`)