### PR TITLE
feat(map-next): Increase contrast in map style and network layer

### DIFF
--- a/packages/map-next/src/lib/components/domain/map/NetworkLayer.svelte
+++ b/packages/map-next/src/lib/components/domain/map/NetworkLayer.svelte
@@ -90,7 +90,7 @@
 				theme.networkLineWidth + 2,
 				theme.networkLineWidth
 			],
-			'line-opacity': ['case', ['get', 'selected'], 0.95, 0.6]
+			'line-opacity': ['case', ['get', 'selected'], 0.9, 0.7]
 		}}
 		interactive={false}
 	/>
@@ -101,9 +101,8 @@
 		id="farm-network-highlight"
 		beforeId={BEFORE_ID}
 		paint={{
-			'circle-radius': ['case', ['get', 'selected'], 18, 13],
+			'circle-radius': ['case', ['get', 'selected'], 16, 12],
 			'circle-color': theme.networkLineColor,
-			'circle-opacity': 0.9,
 			'circle-pitch-alignment': 'map'
 		}}
 		interactive={false}
@@ -117,7 +116,6 @@
 		paint={{
 			'circle-radius': 35,
 			'circle-color': theme.networkLineColor,
-			'circle-opacity': 0.9,
 			'circle-pitch-alignment': 'map'
 		}}
 		interactive={false}

--- a/packages/map-next/src/lib/design/map-style.ts
+++ b/packages/map-next/src/lib/design/map-style.ts
@@ -13,9 +13,9 @@ type MapColorScale = Record<MapShade, string>;
 function createMapColorScale(baseColor: string): MapColorScale {
 	const colorScale = chroma
 		.scale([
-			chroma(baseColor).brighten(1.8).desaturate(0.3),
+			chroma(baseColor).brighten(2).desaturate(0.2),
 			baseColor,
-			chroma(baseColor).darken(1.8).desaturate(0.3)
+			chroma(baseColor).darken(2).desaturate(0.2)
 		])
 		.mode('lab')
 		.colors(shadeSteps.length);

--- a/packages/map-next/src/lib/design/map-style.ts
+++ b/packages/map-next/src/lib/design/map-style.ts
@@ -13,9 +13,9 @@ type MapColorScale = Record<MapShade, string>;
 function createMapColorScale(baseColor: string): MapColorScale {
 	const colorScale = chroma
 		.scale([
-			chroma(baseColor).brighten(2).desaturate(0.2),
+			chroma(baseColor).brighten(2.1).desaturate(0.2),
 			baseColor,
-			chroma(baseColor).darken(2).desaturate(0.2)
+			chroma(baseColor).darken(2.1).desaturate(0.2)
 		])
 		.mode('lab')
 		.colors(shadeSteps.length);


### PR DESCRIPTION
BEFORE / AFTER

<img width="400" height="500" alt="Screenshot 2026-08-02 at 13 24 07" src="https://github.com/user-attachments/assets/06f61041-0983-4c81-a779-d83d9e4d719c" />
<img width="400" height="500" alt="Screenshot 2026-08-02 at 13 26 33" src="https://github.com/user-attachments/assets/cbd8f160-84f0-49eb-9772-465b7551d2b0" />

The difference is rather small. The goal was to improve label while keeping the overall appearance. We can always further improve contrast but adjusting the lightest & darkest color in the scale. 