### PR TITLE
docs: document scripts/link-env.sh in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ npm install
 
 You need to create an `.env` file in the root directory which contains the environment variables needed to run the project. The included `.env.sample` file lists the variables which need to be set.
 
+After creating the root `.env` file, run `scripts/link-env.sh` to symlink it into each package (`packages/api`, `packages/admin`, `packages/map`, `packages/map-next`).
+
 ### Development Mode
 
 Development mode will run the database in a Docker container and populate is with new test data on each run. Make sure you have Docker installed and running on your machine before starting the development server.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -11,13 +11,13 @@
       "source": "sveltejs/ai-tools",
       "sourceType": "github",
       "skillPath": "plugins/claude/svelte/skills/svelte-code-writer/SKILL.md",
-      "computedHash": "c0e2cce9855f8e312cbb0a05aef164b4659c672d7723e4e598ffa6bc94890542"
+      "computedHash": "6f78193a79906175595ce8e4ca8d726da350eb99035a9544b6553620df5673a1"
     },
     "svelte-core-bestpractices": {
       "source": "sveltejs/ai-tools",
       "sourceType": "github",
       "skillPath": "plugins/claude/svelte/skills/svelte-core-bestpractices/SKILL.md",
-      "computedHash": "bec11e369679027edf9d4acbe6d9788f8da33dc14b48b874f231d3ba13705324"
+      "computedHash": "98b4ee346ac45e13740c9f3353b604d5c6e844c96cdc8867052fa961cbdb525d"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add a note to the README's "Configure project settings" section telling developers to run `scripts/link-env.sh` after creating their root `.env` file, so it symlinks the `.env` into `packages/api`, `packages/admin`, `packages/map`, and `packages/map-next`.

## Test plan
- [x] Verified the change renders correctly in README.md