### PR TITLE
feat(map-next): route the contact view and give it a focused-task header

### DIFF
--- a/packages/map-next/README.md
+++ b/packages/map-next/README.md
@@ -60,6 +60,19 @@ npm run build
 - **Route-specific components**: co-located with routes in `src/routes/`
 - **API layer**: `src/lib/api/` (fetch wrappers—use these instead of calling `fetch` directly)
 
+### Sidebar navigation
+
+The sidebar stacks three levels, and each level gets only the tools that belong to it:
+
+- **Browse levels** (entry list): search + region filters.
+- **Selected-entry level** (farm/initiative/depot profile): pivot search — selecting a
+  result replaces the profile — plus back and X. Back restores the pre-detail camera and
+  list scroll position; X only deselects the entry in place, leaving the map as it is.
+- **Task levels** (editors, creation forms, the contact form): a single back button and
+  nothing else. No search header, `focusSearch()` no-ops, and the mobile bottom sheet
+  opens at `full` and cannot be collapsed — a form needs the space, and searching away
+  from a half-written form would silently discard it.
+
 ## Styling
 
 - Use shadcn theme tokens where possible

--- a/packages/map-next/e2e/bottom-sheet.test.ts
+++ b/packages/map-next/e2e/bottom-sheet.test.ts
@@ -157,6 +157,27 @@ test('detail sheet opens at half, expands to full, and peeks back to the map kee
 	}
 });
 
+test('contact sheet opens at full height and cannot be peeked away', async ({ browser }) => {
+	const context = await browser.newContext({ viewport: MOBILE_VIEWPORT });
+	const page = await context.newPage();
+
+	try {
+		await mockSingleFarm(page);
+		// Contact is a task level: unlike the detail sheet (half) it opens at full
+		// and stays expanded, matching the editors.
+		await page.goto('/#/farms/farm-sheet/contact');
+
+		await expect(page.getByTestId('entry-contact-form')).toBeVisible({ timeout: 15000 });
+		await expect.poll(() => shellHeight(page)).toBeGreaterThan(700);
+
+		// Dragging down to peek snaps straight back to the expanded height.
+		await dragHandleTo(page, 820);
+		await expect.poll(() => shellHeight(page)).toBeGreaterThan(700);
+	} finally {
+		await context.close();
+	}
+});
+
 test('mobile focus lifts the selected entry into the upper half, above the sheet', async ({
 	browser
 }) => {

--- a/packages/map-next/e2e/contact-drawer.test.ts
+++ b/packages/map-next/e2e/contact-drawer.test.ts
@@ -96,6 +96,9 @@ test('contact view prefills name/email from the session and back returns to the 
 
 	await page.getByTestId('entry-contact-toggle').click();
 
+	// Feature 1: the contact view is a route of its own, not local profile state.
+	await expect.poll(() => page.url(), { timeout: 15000 }).toContain('#/farms/public-farm/contact');
+
 	// Entry name stays visible in the contact view header, fields are prefilled.
 	await expect(page.getByRole('heading', { name: 'Public Farm' })).toBeVisible();
 	await expect(page.locator('#entry-contact-sender-name')).toHaveValue('Owner User');
@@ -105,10 +108,50 @@ test('contact view prefills name/email from the session and back returns to the 
 	await page.locator('#entry-contact-sender-name').fill('Someone Else');
 	await expect(page.locator('#entry-contact-sender-name')).toHaveValue('Someone Else');
 
-	// Back returns to the profile (contact form unmounted, sections back).
+	// Back returns to the profile route (contact form unmounted, sections back).
 	await page.getByTestId('entry-contact-back').click();
 	await expect(page.getByTestId('entry-contact-form')).toBeHidden();
 	await expect(page.getByTestId('entry-contact-toggle')).toBeVisible();
+	await expect.poll(() => page.url(), { timeout: 15000 }).toMatch(/#\/farms\/public-farm$/);
+});
+
+test('a contact deep link opens the form and browser back returns to the profile', async ({
+	page
+}) => {
+	await mockAuthenticatedUser(page);
+	await mockEntries(page, []);
+
+	// Fresh load straight into the contact route: the form renders for the entry,
+	// and waits for the session so the prefill matches the click path.
+	await page.goto('/#/farms/public-farm/contact');
+	await expect(page.getByTestId('entry-contact-form')).toBeVisible({ timeout: 15000 });
+	await expect(page.getByRole('heading', { name: 'Public Farm' })).toBeVisible();
+	await expect(page.locator('#entry-contact-sender-name')).toHaveValue('Owner User');
+	await expect(page.locator('#entry-contact-sender-email')).toHaveValue('owner@example.com');
+
+	// Opening contact from a profile pushes a history entry, so browser back
+	// returns to the profile rather than dropping all the way to the list.
+	await page.goto('/#/farms/public-farm');
+	await expect(page.getByTestId('entry-contact-toggle')).toBeVisible({ timeout: 15000 });
+	await page.getByTestId('entry-contact-toggle').click();
+	await expect(page.getByTestId('entry-contact-form')).toBeVisible();
+
+	await page.goBack();
+	await expect.poll(() => page.url(), { timeout: 15000 }).toMatch(/#\/farms\/public-farm$/);
+	await expect(page.getByTestId('entry-contact-form')).toBeHidden();
+	await expect(page.getByTestId('entry-contact-toggle')).toBeVisible();
+});
+
+test('a contact deep link for an owned entry redirects to its profile', async ({ page }) => {
+	await mockAuthenticatedUser(page);
+	await mockEntries(page, ['my-farm']); // user owns this farm
+
+	await page.goto('/#/farms/my-farm/contact');
+
+	// Owners edit rather than contact themselves: the contact route bounces to the profile.
+	await expect.poll(() => page.url(), { timeout: 15000 }).toMatch(/#\/farms\/my-farm$/);
+	await expect(page.getByTestId('entry-contact-form')).toHaveCount(0);
+	await expect(page.getByTestId('entry-detail-edit')).toBeVisible();
 });
 
 test('contact CTA is hidden on an entry the current account owns', async ({ page }) => {
@@ -125,7 +168,7 @@ test('contact CTA is hidden on an entry the current account owns', async ({ page
 	await expect(page.getByTestId('entry-contact-toggle')).toHaveCount(0);
 });
 
-test('contact view is force-closed once ownership resolves for an owner', async ({ page }) => {
+test('contact view is left once ownership resolves for an owner', async ({ page }) => {
 	await mockAuthenticatedUser(page);
 
 	// Ownership resolves async: the owned-entries (mine=true) response is delayed so
@@ -154,9 +197,10 @@ test('contact view is force-closed once ownership resolves for an owner', async 
 	await page.getByTestId('entry-contact-toggle').click();
 	await expect(page.getByTestId('entry-contact-form')).toBeVisible();
 
-	// Once myEntries resolves, `canEdit` flips true and the contact view is
-	// unmounted (owners cannot message themselves); the Edit action appears.
+	// Once myEntries resolves the contact route redirects to the profile (owners
+	// cannot message themselves); the Edit action appears.
 	await expect(page.getByTestId('entry-contact-form')).toBeHidden({ timeout: 15000 });
+	await expect.poll(() => page.url(), { timeout: 15000 }).toMatch(/#\/farms\/race-farm$/);
 	await expect(page.getByTestId('entry-contact-toggle')).toHaveCount(0);
 	await expect(page.getByTestId('entry-detail-edit')).toBeVisible();
 });

--- a/packages/map-next/e2e/contact-drawer.test.ts
+++ b/packages/map-next/e2e/contact-drawer.test.ts
@@ -126,6 +126,9 @@ test('a contact deep link opens the form and browser back returns to the profile
 	await page.goto('/#/farms/public-farm/contact');
 	await expect(page.getByTestId('entry-contact-form')).toBeVisible({ timeout: 15000 });
 	await expect(page.getByRole('heading', { name: 'Public Farm' })).toBeVisible();
+	// Feature 2: a focused task gets one back button and no search header.
+	await expect(page.getByTestId('entry-contact-back')).toHaveCount(1);
+	await expect(page.getByTestId('detail-search-back')).toHaveCount(0);
 	await expect(page.locator('#entry-contact-sender-name')).toHaveValue('Owner User');
 	await expect(page.locator('#entry-contact-sender-email')).toHaveValue('owner@example.com');
 

--- a/packages/map-next/src/app.d.ts
+++ b/packages/map-next/src/app.d.ts
@@ -27,6 +27,8 @@ declare global {
 			/** Farm/initiative detail + edit routes. */
 			detailData?: MainEntryFeature;
 			detailType?: MainEntryType;
+			/** Farm/initiative contact routes — same payload, contact view instead of profile. */
+			contactData?: MainEntryFeature;
 			/** Farm/initiative create + edit routes. */
 			editorData?: EntryEditorData;
 			/** Depot edit route. */

--- a/packages/map-next/src/lib/components/domain/farms/FarmProfile.svelte
+++ b/packages/map-next/src/lib/components/domain/farms/FarmProfile.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { goto } from '$app/navigation';
 	import XIcon from '@lucide/svelte/icons/x';
 	import LinkIcon from '@lucide/svelte/icons/link';
 	import ExternalLinkIcon from '@lucide/svelte/icons/external-link';
@@ -9,15 +10,14 @@
 	import { Paragraph } from '$lib/components/typography';
 	import { EditorAccountInfo, EditorSaveBar } from '$lib/components/forms';
 	import {
-		EntryContactView,
 		IdentitySection,
 		DescriptionSection,
 		BadgesSection
 	} from '$lib/components/domain/entries';
-	import { authStore } from '$lib/stores/auth.svelte';
 	import { formatFoundedLine, formatEntryAddress } from '$lib/utils/entry-format';
 	import { safeHttpUrl } from '$lib/utils/url';
 	import { copyProfileLink } from '$lib/utils/share';
+	import { routeBuilders } from '$lib/utils/routes';
 	import {
 		FarmProductsSection,
 		FarmEconomicBehaviorSection,
@@ -127,12 +127,6 @@
 		hasUnsavedChanges: () => hasUnsavedChanges
 	});
 
-	// Feature 5: the contact CTA opens a dedicated drawer view (not an appended
-	// section). Sender fields prefill from the session but stay editable.
-	let showContactForm = $state(false);
-	const contactPrefillName = $derived(authStore.user?.name ?? '');
-	const contactPrefillEmail = $derived(authStore.user?.email ?? '');
-
 	async function handleSubmit() {
 		if (isSaving) {
 			return;
@@ -192,121 +186,84 @@
 	);
 </script>
 
-<!-- `!canEdit` also gates the view (not just the CTA): ownership resolves async
-     (myEntries load), so an owner can open contact before `canEdit` flips true —
-     re-checking here unmounts the view the moment ownership is known (F5.3). -->
-{#if mode === 'read' && showContactForm && properties && !canEdit}
-	<EntryContactView
-		entryId={properties.id}
-		entryType="Farm"
-		entryName={properties.name}
-		initialName={contactPrefillName}
-		initialEmail={contactPrefillEmail}
-		onBack={() => (showContactForm = false)}
-	/>
-{:else}
-	<Sidebar.Header class="border-b border-separator p-2">
-		<div class="flex items-start justify-between gap-2">
-			<div class="flex min-w-0 flex-1 items-start gap-3">
-				<div class="shrink-0 text-muted-foreground">
-					<img class="size-9 object-contain" src={icon} alt={title} />
-				</div>
-				<div class="mt-1 flex min-w-0 flex-1 flex-col gap-1">
-					<!-- The entry name is the header heading in both modes (F4.2); the
-					     editable name field lives inside the Identity section. -->
-					<h2 class="text-lg leading-tight font-semibold text-foreground">{title}</h2>
-					{#if mode === 'read'}
-						{#if address}
-							<Paragraph size="small" muted data-testid="entry-detail-address">
-								{address}
-							</Paragraph>
-						{/if}
-						{#if websiteUrl}
-							<a
-								href={websiteUrl}
-								target="_blank"
-								rel="noopener noreferrer"
-								data-testid="entry-detail-website"
-								class="flex w-fit max-w-full items-center gap-1 text-sm text-primary hover:underline"
-							>
-								<span class="truncate">{websiteUrl}</span>
-								<ExternalLinkIcon class="size-3 shrink-0" />
-							</a>
-						{/if}
-						{#if foundedLine}
-							<Paragraph size="small" muted>{foundedLine}</Paragraph>
-						{/if}
-					{/if}
-				</div>
+<Sidebar.Header class="border-b border-separator p-2">
+	<div class="flex items-start justify-between gap-2">
+		<div class="flex min-w-0 flex-1 items-start gap-3">
+			<div class="shrink-0 text-muted-foreground">
+				<img class="size-9 object-contain" src={icon} alt={title} />
 			</div>
-			<!-- Edit mode keeps a single Cancel affordance in the sticky save bar (F4.3). -->
-			{#if mode === 'read'}
-				<div class="flex shrink-0 items-center gap-1">
-					{#if canEdit && onEdit}
-						<AppButton variant="outline" data-testid="entry-detail-edit" onclick={onEdit}>
-							{m.map_sidebar_action_edit()}
-						</AppButton>
+			<div class="mt-1 flex min-w-0 flex-1 flex-col gap-1">
+				<!-- The entry name is the header heading in both modes (F4.2); the
+				     editable name field lives inside the Identity section. -->
+				<h2 class="text-lg leading-tight font-semibold text-foreground">{title}</h2>
+				{#if mode === 'read'}
+					{#if address}
+						<Paragraph size="small" muted data-testid="entry-detail-address">
+							{address}
+						</Paragraph>
 					{/if}
-					<IconButton
-						class="shrink-0"
-						data-testid="entry-detail-share"
-						label={m.entry_share_action()}
-						onclick={() => void handleShare()}
-					>
-						<LinkIcon />
-					</IconButton>
-					<IconButton
-						class="shrink-0"
-						data-testid="entry-detail-close"
-						label={m.map_token_feedback_dismiss()}
-						onclick={onClose}
-					>
-						<XIcon />
-					</IconButton>
-				</div>
-			{/if}
+					{#if websiteUrl}
+						<a
+							href={websiteUrl}
+							target="_blank"
+							rel="noopener noreferrer"
+							data-testid="entry-detail-website"
+							class="flex w-fit max-w-full items-center gap-1 text-sm text-primary hover:underline"
+						>
+							<span class="truncate">{websiteUrl}</span>
+							<ExternalLinkIcon class="size-3 shrink-0" />
+						</a>
+					{/if}
+					{#if foundedLine}
+						<Paragraph size="small" muted>{foundedLine}</Paragraph>
+					{/if}
+				{/if}
+			</div>
 		</div>
-	</Sidebar.Header>
+		<!-- Edit mode keeps a single Cancel affordance in the sticky save bar (F4.3). -->
+		{#if mode === 'read'}
+			<div class="flex shrink-0 items-center gap-1">
+				{#if canEdit && onEdit}
+					<AppButton variant="outline" data-testid="entry-detail-edit" onclick={onEdit}>
+						{m.map_sidebar_action_edit()}
+					</AppButton>
+				{/if}
+				<IconButton
+					class="shrink-0"
+					data-testid="entry-detail-share"
+					label={m.entry_share_action()}
+					onclick={() => void handleShare()}
+				>
+					<LinkIcon />
+				</IconButton>
+				<IconButton
+					class="shrink-0"
+					data-testid="entry-detail-close"
+					label={m.map_token_feedback_dismiss()}
+					onclick={onClose}
+				>
+					<XIcon />
+				</IconButton>
+			</div>
+		{/if}
+	</div>
+</Sidebar.Header>
 
-	<Sidebar.Content class="overflow-y-auto">
-		{#if mode === 'edit'}
-			<form class="flex flex-col p-4 pb-24" data-testid="entry-editor" onsubmit={handleFormSubmit}>
-				<Paragraph size="small" class="pb-6">{m.user_form_required_fields()}</Paragraph>
+<Sidebar.Content class="overflow-y-auto">
+	{#if mode === 'edit'}
+		<form class="flex flex-col p-4 pb-24" data-testid="entry-editor" onsubmit={handleFormSubmit}>
+			<Paragraph size="small" class="pb-6">{m.user_form_required_fields()}</Paragraph>
 
-				<!-- Same section sequence and divider rhythm as read mode (F4.2 parity);
-				     only the section bodies swap to form controls. -->
-				<div class="flex flex-col divide-y [&>*]:py-6 [&>*:first-child]:pt-0 [&>*:last-child]:pb-0">
-					<IdentitySection mode="edit" {form} markerType="Farm" />
-					<DescriptionSection mode="edit" {form} />
-					<EditorAccountInfo />
-					<FarmProductsSection mode="edit" {form} {products} />
-					<FarmEconomicBehaviorSection mode="edit" {form} />
-					<FarmMembershipSection mode="edit" {form} />
-					<BadgesSection mode="edit" {form} {badges} idPrefix="farm-badge" />
-					<FarmDepotsSection
-						{properties}
-						{ownedDepotIds}
-						isFarmOwner={canEdit}
-						{onDepotSelect}
-						{onDepotEdit}
-						{onDepotDelete}
-						{onAddDepot}
-					/>
-				</div>
-
-				<EditorSaveBar {isSaving} {sectionErrors} onCancel={() => void handleCancel()} />
-			</form>
-		{:else}
-			<!-- Identity (name/location/website) lives in the drawer header in read
-			     mode; the Identity section only appears in edit mode. `divide-y`
-			     draws separators only between rendered sections, so empty sections
-			     produce no stray dividers (F12.2). -->
-			<div class="flex flex-col p-4 [&>*]:py-6 [&>*:first-child]:pt-0 [&>*:last-child]:pb-0">
-				<DescriptionSection mode="read" {properties} {form} />
-				<FarmProductsSection mode="read" {properties} {form} />
-				<FarmEconomicBehaviorSection mode="read" {properties} {form} />
-				<FarmMembershipSection mode="read" {properties} {form} />
-				<BadgesSection mode="read" {properties} {form} idPrefix="farm-badge" />
+			<!-- Same section sequence and divider rhythm as read mode (F4.2 parity);
+			     only the section bodies swap to form controls. -->
+			<div class="flex flex-col divide-y [&>*]:py-6 [&>*:first-child]:pt-0 [&>*:last-child]:pb-0">
+				<IdentitySection mode="edit" {form} markerType="Farm" />
+				<DescriptionSection mode="edit" {form} />
+				<EditorAccountInfo />
+				<FarmProductsSection mode="edit" {form} {products} />
+				<FarmEconomicBehaviorSection mode="edit" {form} />
+				<FarmMembershipSection mode="edit" {form} />
+				<BadgesSection mode="edit" {form} {badges} idPrefix="farm-badge" />
 				<FarmDepotsSection
 					{properties}
 					{ownedDepotIds}
@@ -317,21 +274,44 @@
 					{onAddDepot}
 				/>
 			</div>
-		{/if}
-	</Sidebar.Content>
 
-	<!-- Feature 5.3: the CTA is hidden on entries the current account owns
-	     (`canEdit`), who edit rather than contact themselves. -->
-	{#if mode === 'read' && properties && !canEdit}
-		<Sidebar.Footer class="border-t border-separator p-2">
-			<AppButton
-				type="button"
-				class="w-full"
-				data-testid="entry-contact-toggle"
-				onclick={() => (showContactForm = true)}
-			>
-				{m.entry_contact_button()}
-			</AppButton>
-		</Sidebar.Footer>
+			<EditorSaveBar {isSaving} {sectionErrors} onCancel={() => void handleCancel()} />
+		</form>
+	{:else}
+		<!-- Identity (name/location/website) lives in the drawer header in read
+		     mode; the Identity section only appears in edit mode. `divide-y`
+		     draws separators only between rendered sections, so empty sections
+		     produce no stray dividers (F12.2). -->
+		<div class="flex flex-col p-4 [&>*]:py-6 [&>*:first-child]:pt-0 [&>*:last-child]:pb-0">
+			<DescriptionSection mode="read" {properties} {form} />
+			<FarmProductsSection mode="read" {properties} {form} />
+			<FarmEconomicBehaviorSection mode="read" {properties} {form} />
+			<FarmMembershipSection mode="read" {properties} {form} />
+			<BadgesSection mode="read" {properties} {form} idPrefix="farm-badge" />
+			<FarmDepotsSection
+				{properties}
+				{ownedDepotIds}
+				isFarmOwner={canEdit}
+				{onDepotSelect}
+				{onDepotEdit}
+				{onDepotDelete}
+				{onAddDepot}
+			/>
+		</div>
 	{/if}
+</Sidebar.Content>
+
+<!-- Feature 5.3: the CTA is hidden on entries the current account owns
+     (`canEdit`), who edit rather than contact themselves. -->
+{#if mode === 'read' && properties && !canEdit}
+	<Sidebar.Footer class="border-t border-separator p-2">
+		<AppButton
+			type="button"
+			class="w-full"
+			data-testid="entry-contact-toggle"
+			onclick={() => void goto(routeBuilders.farm.contact(properties.id))}
+		>
+			{m.entry_contact_button()}
+		</AppButton>
+	</Sidebar.Footer>
 {/if}

--- a/packages/map-next/src/lib/components/domain/initiatives/InitiativeProfile.svelte
+++ b/packages/map-next/src/lib/components/domain/initiatives/InitiativeProfile.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { goto } from '$app/navigation';
 	import XIcon from '@lucide/svelte/icons/x';
 	import LinkIcon from '@lucide/svelte/icons/link';
 	import ExternalLinkIcon from '@lucide/svelte/icons/external-link';
@@ -9,15 +10,14 @@
 	import { Paragraph } from '$lib/components/typography';
 	import { EditorAccountInfo, EditorSaveBar } from '$lib/components/forms';
 	import {
-		EntryContactView,
 		IdentitySection,
 		DescriptionSection,
 		BadgesSection
 	} from '$lib/components/domain/entries';
-	import { authStore } from '$lib/stores/auth.svelte';
 	import { formatEntryAddress } from '$lib/utils/entry-format';
 	import { safeHttpUrl } from '$lib/utils/url';
 	import { copyProfileLink } from '$lib/utils/share';
+	import { routeBuilders } from '$lib/utils/routes';
 	import { InitiativeGoalsSection } from './sections';
 	import * as m from '$lib/paraglide/messages.js';
 	import { getPlaceIcon } from '$lib/utils/marker-icons';
@@ -105,12 +105,6 @@
 		hasUnsavedChanges: () => hasUnsavedChanges
 	});
 
-	// Feature 5: the contact CTA opens a dedicated drawer view (not an appended
-	// section). Sender fields prefill from the session but stay editable.
-	let showContactForm = $state(false);
-	const contactPrefillName = $derived(authStore.user?.name ?? '');
-	const contactPrefillEmail = $derived(authStore.user?.email ?? '');
-
 	async function handleSubmit() {
 		if (isSaving) {
 			return;
@@ -172,122 +166,108 @@
 	);
 </script>
 
-<!-- `!canEdit` also gates the view (not just the CTA): ownership resolves async
-     (myEntries load), so an owner can open contact before `canEdit` flips true —
-     re-checking here unmounts the view the moment ownership is known (F5.3). -->
-{#if mode === 'read' && showContactForm && properties && !canEdit}
-	<EntryContactView
-		entryId={properties.id}
-		entryType="Initiative"
-		entryName={properties.name}
-		initialName={contactPrefillName}
-		initialEmail={contactPrefillEmail}
-		onBack={() => (showContactForm = false)}
-	/>
-{:else}
-	<Sidebar.Header class="border-b border-separator">
-		<div class="flex items-start justify-between gap-2">
-			<div class="flex min-w-0 flex-1 items-start gap-3">
-				<div class="shrink-0 text-muted-foreground">
-					<img class="size-9 object-contain" src={icon} alt={title} />
-				</div>
-				<div class="mt-1 flex min-w-0 flex-1 flex-col gap-1">
-					<!-- The entry name is the header heading in both modes (F4.2); the
-					     editable name field lives inside the Identity section. -->
-					<h2 class="text-lg leading-tight font-semibold text-foreground">{title}</h2>
-					{#if mode === 'read'}
-						{#if address}
-							<Paragraph size="small" muted data-testid="entry-detail-address">
-								{address}
-							</Paragraph>
-						{/if}
-						{#if websiteUrl}
-							<a
-								href={websiteUrl}
-								target="_blank"
-								rel="noopener noreferrer"
-								data-testid="entry-detail-website"
-								class="flex w-fit max-w-full items-center gap-1 text-sm text-primary hover:underline"
-							>
-								<span class="truncate">{websiteUrl}</span>
-								<ExternalLinkIcon class="size-3 shrink-0" />
-							</a>
-						{/if}
-					{/if}
-				</div>
+<Sidebar.Header class="border-b border-separator">
+	<div class="flex items-start justify-between gap-2">
+		<div class="flex min-w-0 flex-1 items-start gap-3">
+			<div class="shrink-0 text-muted-foreground">
+				<img class="size-9 object-contain" src={icon} alt={title} />
 			</div>
-			<!-- Edit mode keeps a single Cancel affordance in the sticky save bar (F4.3). -->
-			{#if mode === 'read'}
-				<div class="flex shrink-0 items-center gap-1">
-					{#if canEdit && onEdit}
-						<AppButton variant="outline" data-testid="entry-detail-edit" onclick={onEdit}>
-							{m.map_sidebar_action_edit()}
-						</AppButton>
+			<div class="mt-1 flex min-w-0 flex-1 flex-col gap-1">
+				<!-- The entry name is the header heading in both modes (F4.2); the
+				     editable name field lives inside the Identity section. -->
+				<h2 class="text-lg leading-tight font-semibold text-foreground">{title}</h2>
+				{#if mode === 'read'}
+					{#if address}
+						<Paragraph size="small" muted data-testid="entry-detail-address">
+							{address}
+						</Paragraph>
 					{/if}
-					<IconButton
-						class="shrink-0"
-						data-testid="entry-detail-share"
-						label={m.entry_share_action()}
-						onclick={() => void handleShare()}
-					>
-						<LinkIcon />
-					</IconButton>
-					<IconButton
-						class="shrink-0"
-						data-testid="entry-detail-close"
-						label={m.map_token_feedback_dismiss()}
-						onclick={onClose}
-					>
-						<XIcon />
-					</IconButton>
-				</div>
-			{/if}
+					{#if websiteUrl}
+						<a
+							href={websiteUrl}
+							target="_blank"
+							rel="noopener noreferrer"
+							data-testid="entry-detail-website"
+							class="flex w-fit max-w-full items-center gap-1 text-sm text-primary hover:underline"
+						>
+							<span class="truncate">{websiteUrl}</span>
+							<ExternalLinkIcon class="size-3 shrink-0" />
+						</a>
+					{/if}
+				{/if}
+			</div>
 		</div>
-	</Sidebar.Header>
-
-	<Sidebar.Content class="overflow-y-auto">
-		{#if mode === 'edit'}
-			<form class="flex flex-col p-4 pb-24" data-testid="entry-editor" onsubmit={handleFormSubmit}>
-				<Paragraph size="small" class="pb-1">{m.user_form_required_fields()}</Paragraph>
-				<Paragraph size="small" class="pb-6">{m.editor_initiative_intro()}</Paragraph>
-
-				<!-- Same section sequence and divider rhythm as read mode (F4.2 parity);
-				     only the section bodies swap to form controls. -->
-				<div class="flex flex-col [&>*]:py-6 [&>*:first-child]:pt-0 [&>*:last-child]:pb-0">
-					<IdentitySection mode="edit" {form} markerType="Initiative" />
-					<DescriptionSection mode="edit" {form} />
-					<EditorAccountInfo />
-					<InitiativeGoalsSection mode="edit" {form} {goals} />
-					<BadgesSection mode="edit" {form} {badges} idPrefix="initiative-badge" />
-				</div>
-
-				<EditorSaveBar {isSaving} {sectionErrors} onCancel={() => void handleCancel()} />
-			</form>
-		{:else}
-			<!-- Identity (name/location/website) lives in the drawer header in read
-			     mode; the Identity section only appears in edit mode. `divide-y`
-			     draws separators only between rendered sections, so empty sections
-			     produce no stray dividers (F12.2). -->
-			<div class="flex flex-col p-4 [&>*]:py-6 [&>*:first-child]:pt-0 [&>*:last-child]:pb-0">
-				<DescriptionSection mode="read" {properties} {form} />
-				<InitiativeGoalsSection mode="read" {properties} {form} />
-				<BadgesSection mode="read" {properties} {form} idPrefix="initiative-badge" />
+		<!-- Edit mode keeps a single Cancel affordance in the sticky save bar (F4.3). -->
+		{#if mode === 'read'}
+			<div class="flex shrink-0 items-center gap-1">
+				{#if canEdit && onEdit}
+					<AppButton variant="outline" data-testid="entry-detail-edit" onclick={onEdit}>
+						{m.map_sidebar_action_edit()}
+					</AppButton>
+				{/if}
+				<IconButton
+					class="shrink-0"
+					data-testid="entry-detail-share"
+					label={m.entry_share_action()}
+					onclick={() => void handleShare()}
+				>
+					<LinkIcon />
+				</IconButton>
+				<IconButton
+					class="shrink-0"
+					data-testid="entry-detail-close"
+					label={m.map_token_feedback_dismiss()}
+					onclick={onClose}
+				>
+					<XIcon />
+				</IconButton>
 			</div>
 		{/if}
-	</Sidebar.Content>
+	</div>
+</Sidebar.Header>
 
-	<!-- Feature 5.3: the CTA is hidden on entries the current account owns
-	     (`canEdit`), who edit rather than contact themselves. -->
-	{#if mode === 'read' && properties && !canEdit}
-		<Sidebar.Footer class="border-t border-separator p-4">
-			<AppButton
-				type="button"
-				class="w-full"
-				data-testid="entry-contact-toggle"
-				onclick={() => (showContactForm = true)}
-			>
-				{m.entry_contact_button()}
-			</AppButton>
-		</Sidebar.Footer>
+<Sidebar.Content class="overflow-y-auto">
+	{#if mode === 'edit'}
+		<form class="flex flex-col p-4 pb-24" data-testid="entry-editor" onsubmit={handleFormSubmit}>
+			<Paragraph size="small" class="pb-1">{m.user_form_required_fields()}</Paragraph>
+			<Paragraph size="small" class="pb-6">{m.editor_initiative_intro()}</Paragraph>
+
+			<!-- Same section sequence and divider rhythm as read mode (F4.2 parity);
+			     only the section bodies swap to form controls. -->
+			<div class="flex flex-col [&>*]:py-6 [&>*:first-child]:pt-0 [&>*:last-child]:pb-0">
+				<IdentitySection mode="edit" {form} markerType="Initiative" />
+				<DescriptionSection mode="edit" {form} />
+				<EditorAccountInfo />
+				<InitiativeGoalsSection mode="edit" {form} {goals} />
+				<BadgesSection mode="edit" {form} {badges} idPrefix="initiative-badge" />
+			</div>
+
+			<EditorSaveBar {isSaving} {sectionErrors} onCancel={() => void handleCancel()} />
+		</form>
+	{:else}
+		<!-- Identity (name/location/website) lives in the drawer header in read
+		     mode; the Identity section only appears in edit mode. `divide-y`
+		     draws separators only between rendered sections, so empty sections
+		     produce no stray dividers (F12.2). -->
+		<div class="flex flex-col p-4 [&>*]:py-6 [&>*:first-child]:pt-0 [&>*:last-child]:pb-0">
+			<DescriptionSection mode="read" {properties} {form} />
+			<InitiativeGoalsSection mode="read" {properties} {form} />
+			<BadgesSection mode="read" {properties} {form} idPrefix="initiative-badge" />
+		</div>
 	{/if}
+</Sidebar.Content>
+
+<!-- Feature 5.3: the CTA is hidden on entries the current account owns
+     (`canEdit`), who edit rather than contact themselves. -->
+{#if mode === 'read' && properties && !canEdit}
+	<Sidebar.Footer class="border-t border-separator p-4">
+		<AppButton
+			type="button"
+			class="w-full"
+			data-testid="entry-contact-toggle"
+			onclick={() => void goto(routeBuilders.initiative.contact(properties.id))}
+		>
+			{m.entry_contact_button()}
+		</AppButton>
+	</Sidebar.Footer>
 {/if}

--- a/packages/map-next/src/lib/components/layout/SidebarShell.svelte
+++ b/packages/map-next/src/lib/components/layout/SidebarShell.svelte
@@ -9,8 +9,12 @@
 	interface Props {
 		/** Compact state: collapsed floating card (desktop) / peek snap (mobile). */
 		collapsed?: boolean;
-		/** Which content the shell currently hosts; drives the mobile snap point. */
-		mode?: 'list' | 'detail' | 'editor';
+		/**
+		 * Which content the shell currently hosts; drives the mobile snap point.
+		 * `task` and `editor` are both focused tasks (full sheet, no collapse);
+		 * only `editor` also widens the desktop drawer.
+		 */
+		mode?: 'list' | 'detail' | 'task' | 'editor';
 		/**
 		 * Mobile only: force the sheet to full height (e.g. while the search input
 		 * is focused with the keyboard open). Releasing it restores the previous
@@ -33,14 +37,14 @@
 	// `collapsed` so peek ↔ expanded toggling never loses the chosen height.
 	let expandedLevel = $state<Exclude<BottomSheetSnap, 'peek'>>('half');
 
-	// Detail opens at half, editors at full — reconcile on each mode transition
-	// (including the initial one, e.g. a deep link straight into an editor) so a
-	// deliberate user drag afterwards is not immediately overridden.
+	// Detail opens at half, focused tasks at full — reconcile on each mode
+	// transition (including the initial one, e.g. a deep link straight into an
+	// editor) so a deliberate user drag afterwards is not immediately overridden.
 	let previousMode = $state<Props['mode'] | undefined>(undefined);
 	$effect(() => {
 		if (mode === previousMode) return;
 		previousMode = mode;
-		if (mode === 'editor') {
+		if (mode === 'editor' || mode === 'task') {
 			expandedLevel = 'full';
 			collapsed = false;
 		} else if (mode === 'detail') {
@@ -65,7 +69,7 @@
 	// squeezed into a small box; only the list keeps the bounded card height.
 	const desktopPositionClass = $derived.by(() => {
 		if (collapsed) return 'top-auto bottom-2.5 h-auto';
-		if (mode === 'editor' || mode === 'detail') return 'top-2.5 bottom-2.5';
+		if (mode !== 'list') return 'top-2.5 bottom-2.5';
 		return 'bottom-2.5 h-[min(70vh,36rem)]';
 	});
 	const desktopBreakpointPositionClass = $derived(

--- a/packages/map-next/src/lib/utils/routes.spec.ts
+++ b/packages/map-next/src/lib/utils/routes.spec.ts
@@ -20,6 +20,8 @@ describe('routes utils', () => {
 		expect(routeBuilders.auth.signIn()).toBe('#/users/sign-in');
 		expect(routeBuilders.farm.detail('42')).toBe('#/farms/42');
 		expect(routeBuilders.initiative.edit('abc')).toBe('#/initiatives/abc/edit');
+		expect(routeBuilders.farm.contact('42')).toBe('#/farms/42/contact');
+		expect(routeBuilders.initiative.contact('abc')).toBe('#/initiatives/abc/contact');
 		expect(routeBuilders.discovery.position(47.37, 8.54)).toBe('#/position/47.37,8.54');
 	});
 
@@ -36,6 +38,12 @@ describe('routes utils', () => {
 		expect(parsed.params.id).toBe('farm-123');
 		expect(parsed.query.get('tab')).toBe('contact');
 		expect(parsed.isLegacyAlias).toBe(false);
+	});
+
+	it('parses contact routes ahead of the detail matcher', () => {
+		expect(parseHashRoute('#/farms/farm-123/contact').kind).toBe('farm-contact');
+		expect(parseHashRoute('#/initiatives/init-1/contact').params.id).toBe('init-1');
+		expect(parseHashRoute('#/initiatives/init-1/contact').kind).toBe('initiative-contact');
 	});
 
 	it('parses legacy aliases and marks them as legacy', () => {

--- a/packages/map-next/src/lib/utils/routes.ts
+++ b/packages/map-next/src/lib/utils/routes.ts
@@ -73,11 +73,13 @@ export const routeBuilders = {
 	farm: {
 		detail: (id: string) => toHashRoute(`/farms/${encodeURIComponent(id)}`),
 		edit: (id: string) => toHashRoute(`/farms/${encodeURIComponent(id)}/edit`),
+		contact: (id: string) => toHashRoute(`/farms/${encodeURIComponent(id)}/contact`),
 		create: () => hashRoutes.create.farm
 	},
 	initiative: {
 		detail: (id: string) => toHashRoute(`/initiatives/${encodeURIComponent(id)}`),
 		edit: (id: string) => toHashRoute(`/initiatives/${encodeURIComponent(id)}/edit`),
+		contact: (id: string) => toHashRoute(`/initiatives/${encodeURIComponent(id)}/contact`),
 		create: () => hashRoutes.create.initiative
 	},
 	depotLegacy: {
@@ -127,9 +129,11 @@ export type HashRouteKind =
 	| 'auth-reset-password'
 	| 'farm-detail'
 	| 'farm-edit'
+	| 'farm-contact'
 	| 'farm-create'
 	| 'initiative-detail'
 	| 'initiative-edit'
+	| 'initiative-contact'
 	| 'initiative-create'
 	| 'location'
 	| 'position'
@@ -160,10 +164,12 @@ const ROUTE_MATCHERS: readonly RouteMatcher[] = [
 
 	{ kind: 'farm-create', pattern: /^\/farms\/new$/ },
 	{ kind: 'farm-edit', pattern: /^\/farms\/(?<id>[^/]+)\/edit$/ },
+	{ kind: 'farm-contact', pattern: /^\/farms\/(?<id>[^/]+)\/contact$/ },
 	{ kind: 'farm-detail', pattern: /^\/farms\/(?<id>[^/]+)$/ },
 
 	{ kind: 'initiative-create', pattern: /^\/initiatives\/new$/ },
 	{ kind: 'initiative-edit', pattern: /^\/initiatives\/(?<id>[^/]+)\/edit$/ },
+	{ kind: 'initiative-contact', pattern: /^\/initiatives\/(?<id>[^/]+)\/contact$/ },
 	{ kind: 'initiative-detail', pattern: /^\/initiatives\/(?<id>[^/]+)$/ },
 
 	{ kind: 'location', pattern: /^\/locations\/(?<id>[^/]+)$/ },

--- a/packages/map-next/src/routes/MapSidebar.svelte
+++ b/packages/map-next/src/routes/MapSidebar.svelte
@@ -847,7 +847,7 @@
 <!-- Slim persistent header keeps search reachable from an open profile; selecting
      a result replaces the profile (handleSearchSuggestionSelect navigates). Task
      levels — editors, creation forms, the contact form — render no search
-     (F10 focused-task rule). -->
+     (F10 focused-task rule; see "Sidebar navigation" in packages/map-next/README.md). -->
 {#snippet detailSearchHeader()}
 	<SlimSearchHeader
 		bind:searchValue

--- a/packages/map-next/src/routes/MapSidebar.svelte
+++ b/packages/map-next/src/routes/MapSidebar.svelte
@@ -17,6 +17,7 @@
 	import type { RegionOption } from '$lib/utils/regions';
 	import {
 		EntriesList,
+		EntryContactView,
 		MyEntriesCreateActions,
 		MyEntriesList,
 		ProfileSkeleton
@@ -145,6 +146,7 @@
 
 	// Detail view from route data (loaded by +page.ts)
 	const detailData = $derived(page.data.detailData);
+	const contactData = $derived(page.data.contactData);
 	const editorData = $derived(page.data.editorData);
 	const depotDetailData = $derived(page.data.depotDetailData);
 	const depotEditorData = $derived(page.data.depotEditorData);
@@ -157,9 +159,11 @@
 	const DATA_ROUTE_IDS = new Set([
 		'/farms/[id]',
 		'/farms/[id]/edit',
+		'/farms/[id]/contact',
 		'/farms/new',
 		'/initiatives/[id]',
 		'/initiatives/[id]/edit',
+		'/initiatives/[id]/contact',
 		'/initiatives/new',
 		'/depots/[id]/edit',
 		'/depots/new',
@@ -169,9 +173,10 @@
 		navigating.to != null && DATA_ROUTE_IDS.has(navigating.to.route.id ?? '')
 	);
 	const showDetail = $derived(!!detailData);
+	const showContact = $derived(!!contactData);
 	const showEditor = $derived(!!editorData);
 	const showDepotEditor = $derived(!!depotEditorData);
-	const isNonListMode = $derived(showDetail || showEditor || showDepotEditor);
+	const isNonListMode = $derived(showDetail || showContact || showEditor || showDepotEditor);
 	const isEditorMode = $derived(showEditor || showDepotEditor);
 	// Profile inline edit (Feature 4 & 9): farms and initiatives render their
 	// section-based FarmProfile/InitiativeProfile for read, edit, and create.
@@ -242,7 +247,7 @@
 	// from peek, desktop card uncollapses) and the error state is actually
 	// visible instead of clipped inside the peek-height sheet.
 	const shellMode = $derived<'list' | 'detail' | 'editor'>(
-		isEditorMode ? 'editor' : showDetail || loadError ? 'detail' : 'list'
+		isEditorMode ? 'editor' : showDetail || showContact || loadError ? 'detail' : 'list'
 	);
 	// On mobile the bottom sheet stays mounted at every snap point (so dragging
 	// between peek/half/full reveals live content); content is only unmounted for
@@ -261,14 +266,27 @@
 
 	// Track when detail route changes to trigger map pan
 	let lastDetailId = $state<string | null>(null);
+	// The contact route frames its entry exactly like the detail route, so a deep
+	// link into contact focuses the map the same way (and detail↔contact for the
+	// same entry keeps the camera put).
+	const focusedEntry = $derived(detailData ?? contactData);
 
 	$effect(() => {
-		if (detailData && detailData.properties.id !== lastDetailId) {
+		if (focusedEntry && focusedEntry.properties.id !== lastDetailId) {
 			// Pan from resolved detail data (works for deep-link and redirect loads, too).
-			onEntryClick?.(detailData as EntryFeature, { openPopup: true });
-			lastDetailId = detailData.properties.id;
-		} else if (!detailData) {
+			onEntryClick?.(focusedEntry as EntryFeature, { openPopup: true });
+			lastDetailId = focusedEntry.properties.id;
+		} else if (!focusedEntry) {
 			lastDetailId = null;
+		}
+	});
+
+	// Owners get edit affordances instead of a contact CTA, so a contact deep link
+	// for an entry they own redirects to its profile. Ownership resolves async (the
+	// myEntries load), so this also closes the view if it opened before it resolved.
+	$effect(() => {
+		if (contactData && ownedMainEntryIds.has(contactData.properties.id)) {
+			handleContactBack();
 		}
 	});
 
@@ -688,6 +706,19 @@
 		handleCloseDetail();
 	}
 
+	// Back from the contact view (and a successful send) returns to the profile.
+	// `replaceState` (as in `handleEditorCancel`) drops the contact entry rather
+	// than stacking a second profile entry on top of it, so returning here twice
+	// never buries the list under a pile of history.
+	function handleContactBack() {
+		if (!contactData) {
+			return;
+		}
+		void goto(routeBuilders.entryDetail(contactData.properties.type, contactData.properties.id), {
+			replaceState: true
+		});
+	}
+
 	function handleEditFromDetail() {
 		if (!detailData) {
 			return;
@@ -879,6 +910,25 @@
 				onSaved={handleEditorSaved}
 			/>
 		{/key}
+	{:else if showContact && contactData}
+		{@render detailSearchHeader()}
+		{#if !isAuthInitialized}
+			<!-- The form snapshots its prefill props at mount and never re-syncs, so a
+			     contact deep link must wait for the session before mounting it —
+			     otherwise a signed-in sender gets empty name/email fields. -->
+			<ProfileSkeleton />
+		{:else}
+			{#key `contact:${contactData.properties.id}`}
+				<EntryContactView
+					entryId={contactData.properties.id}
+					entryType={contactData.properties.type}
+					entryName={contactData.properties.name}
+					initialName={authStore.user?.name ?? ''}
+					initialEmail={authStore.user?.email ?? ''}
+					onBack={handleContactBack}
+				/>
+			{/key}
+		{/if}
 	{:else if isFarmDetail && detailData}
 		{@render detailSearchHeader()}
 		{#key `farm:${detailData.properties.id}`}

--- a/packages/map-next/src/routes/MapSidebar.svelte
+++ b/packages/map-next/src/routes/MapSidebar.svelte
@@ -178,6 +178,9 @@
 	const showDepotEditor = $derived(!!depotEditorData);
 	const isNonListMode = $derived(showDetail || showContact || showEditor || showDepotEditor);
 	const isEditorMode = $derived(showEditor || showDepotEditor);
+	// Task levels (editors and the contact form) are focused tasks, not browse
+	// levels: no search header, mobile sheet at full, collapse forbidden.
+	const isTaskLevel = $derived(isEditorMode || showContact);
 	// Profile inline edit (Feature 4 & 9): farms and initiatives render their
 	// section-based FarmProfile/InitiativeProfile for read, edit, and create.
 	// Creation is the same section form as editing with no existing entry to
@@ -246,8 +249,8 @@
 	// A failed load counts as 'detail' so the shell expands (mobile sheet rises
 	// from peek, desktop card uncollapses) and the error state is actually
 	// visible instead of clipped inside the peek-height sheet.
-	const shellMode = $derived<'list' | 'detail' | 'editor'>(
-		isEditorMode ? 'editor' : showDetail || showContact || loadError ? 'detail' : 'list'
+	const shellMode = $derived<'list' | 'detail' | 'task' | 'editor'>(
+		isEditorMode ? 'editor' : showContact ? 'task' : showDetail || loadError ? 'detail' : 'list'
 	);
 	// On mobile the bottom sheet stays mounted at every snap point (so dragging
 	// between peek/half/full reveals live content); content is only unmounted for
@@ -257,8 +260,8 @@
 	$effect(() => {
 		// Keep detail/editor routes reachable: avoid rendering them in the collapsed
 		// desktop card. On the mobile bottom sheet a detail view may still snap to
-		// peek (map returns to view, selection kept), but editors stay expanded.
-		const forbidCollapse = !isMobile.current || isEditorMode;
+		// peek (map returns to view, selection kept), but task levels stay expanded.
+		const forbidCollapse = !isMobile.current || isTaskLevel;
 		if (isNonListMode && collapsed && forbidCollapse) {
 			collapsed = false;
 		}
@@ -296,11 +299,11 @@
 	}
 
 	// Expose search focusing for the app-root keyboard shortcut (`/` and ⌘K).
-	// Editors and creation forms deliberately hide the search, so this is a no-op there.
+	// Task levels deliberately hide the search, so this is a no-op there.
 	export function focusSearch() {
-		// No search surface in editors/creation forms, and the input is disabled in
-		// my-entries scope — focusing a disabled input is a silent no-op, so bail.
-		if (isEditorMode || isMyEntriesScope) {
+		// No search surface on task levels, and the input is disabled in my-entries
+		// scope — focusing a disabled input is a silent no-op, so bail.
+		if (isTaskLevel || isMyEntriesScope) {
 			return;
 		}
 		collapsed = false;
@@ -842,8 +845,9 @@
 </script>
 
 <!-- Slim persistent header keeps search reachable from an open profile; selecting
-     a result replaces the profile (handleSearchSuggestionSelect navigates). Editors
-     and creation forms render no search (F10 focused-task rule). -->
+     a result replaces the profile (handleSearchSuggestionSelect navigates). Task
+     levels — editors, creation forms, the contact form — render no search
+     (F10 focused-task rule). -->
 {#snippet detailSearchHeader()}
 	<SlimSearchHeader
 		bind:searchValue
@@ -911,7 +915,6 @@
 			/>
 		{/key}
 	{:else if showContact && contactData}
-		{@render detailSearchHeader()}
 		{#if !isAuthInitialized}
 			<!-- The form snapshots its prefill props at mount and never re-syncs, so a
 			     contact deep link must wait for the session before mounting it —

--- a/packages/map-next/src/routes/MapSidebar.svelte.spec.ts
+++ b/packages/map-next/src/routes/MapSidebar.svelte.spec.ts
@@ -423,6 +423,56 @@ describe('MapSidebar', () => {
 		);
 	});
 
+	it('contact view renders a single back button and no search input', async () => {
+		pageState.url = new URL('http://localhost/#/farms/farm-1/contact');
+		pageState.data = { contactData: createFarmDetail('farm-1', 'Farm One') };
+
+		render(MapSidebar, { props: { entries: emptyEntries } });
+
+		await expect
+			.poll(() => !!document.querySelector('[data-testid="entry-contact-form"]'))
+			.toBe(true);
+		expect(document.querySelectorAll('[data-testid="entry-contact-back"]').length).toBe(1);
+		expect(document.querySelectorAll('[data-testid="detail-search-back"]').length).toBe(0);
+		// The only aria-labelled input in the sidebar is the search field.
+		expect(document.querySelectorAll('input[aria-label]').length).toBe(0);
+	});
+
+	it('focusSearch is a no-op while the contact view is open', async () => {
+		pageState.url = new URL('http://localhost/#/farms/farm-1/contact');
+		pageState.data = { contactData: createFarmDetail('farm-1', 'Farm One') };
+
+		const view = render(MapSidebar, { props: { entries: emptyEntries } });
+
+		await expect
+			.poll(() => !!document.querySelector('[data-testid="entry-contact-form"]'))
+			.toBe(true);
+		const messageField = document.querySelector('#entry-contact-message');
+		if (!(messageField instanceof HTMLElement)) {
+			throw new Error('Expected the contact message field');
+		}
+		messageField.focus();
+
+		view.component.focusSearch();
+		// focusSearch() focuses on the next frame, so wait one out before asserting.
+		await new Promise((resolve) => requestAnimationFrame(resolve));
+
+		expect(document.activeElement).toBe(messageField);
+	});
+
+	it('detail view keeps the slim search header alongside the profile actions', async () => {
+		pageState.url = new URL('http://localhost/#/farms/farm-1');
+		pageState.data = { detailData: createFarmDetail('farm-1', 'Farm One') };
+
+		render(MapSidebar, { props: { entries: emptyEntries } });
+
+		await expect
+			.poll(() => !!document.querySelector('[data-testid="detail-search-back"]'))
+			.toBe(true);
+		expect(document.querySelector('input[aria-label]')).toBeTruthy();
+		expect(document.querySelector('[data-testid="entry-detail-close"]')).toBeTruthy();
+	});
+
 	it('exposes accessible labels for key sidebar controls', async () => {
 		pageState.url = new URL('http://localhost/#/');
 		pageState.data = {};

--- a/packages/map-next/src/routes/farms/[id]/contact/+page.svelte
+++ b/packages/map-next/src/routes/farms/[id]/contact/+page.svelte
@@ -1,0 +1,3 @@
+<script lang="ts">
+	// This page exists for routing - contact view is rendered in MapSidebar
+</script>

--- a/packages/map-next/src/routes/farms/[id]/contact/+page.ts
+++ b/packages/map-next/src/routes/farms/[id]/contact/+page.ts
@@ -1,0 +1,16 @@
+import type { PageLoad } from './$types';
+import { getMainEntry } from '$lib/api/entry-details';
+import { loadCatching } from '$lib/utils/load-error';
+import { routeBuilders } from '$lib/utils/routes';
+
+// The entry payload is returned under `contactData` (not `detailData`) so the
+// drawer renders the contact view instead of the profile for the same entry.
+export const load: PageLoad = ({ params }) =>
+	loadCatching(
+		routeBuilders.farm.contact(params.id),
+		async () => {
+			const contactData = await getMainEntry('farms', params.id);
+			return { contactData, detailType: 'Farm' as const };
+		},
+		{ detailType: 'Farm' as const }
+	);

--- a/packages/map-next/src/routes/initiatives/[id]/contact/+page.svelte
+++ b/packages/map-next/src/routes/initiatives/[id]/contact/+page.svelte
@@ -1,0 +1,3 @@
+<script lang="ts">
+	// This page exists for routing - contact view is rendered in MapSidebar
+</script>

--- a/packages/map-next/src/routes/initiatives/[id]/contact/+page.ts
+++ b/packages/map-next/src/routes/initiatives/[id]/contact/+page.ts
@@ -1,0 +1,16 @@
+import type { PageLoad } from './$types';
+import { getMainEntry } from '$lib/api/entry-details';
+import { loadCatching } from '$lib/utils/load-error';
+import { routeBuilders } from '$lib/utils/routes';
+
+// The entry payload is returned under `contactData` (not `detailData`) so the
+// drawer renders the contact view instead of the profile for the same entry.
+export const load: PageLoad = ({ params }) =>
+	loadCatching(
+		routeBuilders.initiative.contact(params.id),
+		async () => {
+			const contactData = await getMainEntry('initiatives', params.id);
+			return { contactData, detailType: 'Initiative' as const };
+		},
+		{ detailType: 'Initiative' as const }
+	);

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -11,13 +11,13 @@
       "source": "sveltejs/ai-tools",
       "sourceType": "github",
       "skillPath": "plugins/claude/svelte/skills/svelte-code-writer/SKILL.md",
-      "computedHash": "c0e2cce9855f8e312cbb0a05aef164b4659c672d7723e4e598ffa6bc94890542"
+      "computedHash": "6f78193a79906175595ce8e4ca8d726da350eb99035a9544b6553620df5673a1"
     },
     "svelte-core-bestpractices": {
       "source": "sveltejs/ai-tools",
       "sourceType": "github",
       "skillPath": "plugins/claude/svelte/skills/svelte-core-bestpractices/SKILL.md",
-      "computedHash": "bec11e369679027edf9d4acbe6d9788f8da33dc14b48b874f231d3ba13705324"
+      "computedHash": "98b4ee346ac45e13740c9f3353b604d5c6e844c96cdc8867052fa961cbdb525d"
     }
   }
 }

--- a/specs/map-next-panel-nav-consistency/plan.md
+++ b/specs/map-next-panel-nav-consistency/plan.md
@@ -4,13 +4,13 @@ Spec: specs/map-next-panel-nav-consistency/spec.md
 
 Status legend: [ ] todo · [~] in progress · [x] done
 
-- [ ] 1. Routed contact view (depends on: none)
-  - [ ] 1.1 Add `farm.contact(id)` and `initiative.contact(id)` to `hashRoutes`/`routeBuilders` in `src/lib/utils/routes.ts`, and extend the route parser/matchers (`HashRouteKind` section) to recognize the new paths.
-  - [ ] 1.2 Add loaders `src/routes/farms/[id]/contact/+page.ts` and `src/routes/initiatives/[id]/contact/+page.ts` that reuse the detail loaders via `loadCatching` and return the detail payload under a contact marker (e.g. `contactData`), including the existing `loadError` path.
-  - [ ] 1.3 In `MapSidebar.svelte`, derive the contact mode from `page.data.contactData` in the existing `{#if}` chain and render `EntryContactView` + `EntryContactForm` there; pan/focus the map on the entry the same way the detail branch does (deep-link parity).
-  - [ ] 1.4 Redirect owners: when the signed-in user can edit the entry (same `canEdit` logic that hides the contact CTA), navigate from the contact route to the entry's detail route.
-  - [ ] 1.5 Remove the `showContactForm` local state and contact branch from `FarmProfile.svelte` and `InitiativeProfile.svelte`; change the contact CTA to `goto(routeBuilders.….contact(id))`; contact back button and successful send `goto` the detail route, keeping the success toast.
-  - [ ] 1.6 Update `e2e/contact-drawer.test.ts` for the routed flow (URL hash changes, browser back → detail) and add a deep-link test that loads `#/farms/:id/contact` fresh and sees the form.
+- [x] 1. Routed contact view (depends on: none)
+  - [x] 1.1 Add `farm.contact(id)` and `initiative.contact(id)` to `hashRoutes`/`routeBuilders` in `src/lib/utils/routes.ts`, and extend the route parser/matchers (`HashRouteKind` section) to recognize the new paths.
+  - [x] 1.2 Add loaders `src/routes/farms/[id]/contact/+page.ts` and `src/routes/initiatives/[id]/contact/+page.ts` that reuse the detail loaders via `loadCatching` and return the detail payload under a contact marker (e.g. `contactData`), including the existing `loadError` path.
+  - [x] 1.3 In `MapSidebar.svelte`, derive the contact mode from `page.data.contactData` in the existing `{#if}` chain and render `EntryContactView` + `EntryContactForm` there; pan/focus the map on the entry the same way the detail branch does (deep-link parity).
+  - [x] 1.4 Redirect owners: when the signed-in user can edit the entry (same `canEdit` logic that hides the contact CTA), navigate from the contact route to the entry's detail route.
+  - [x] 1.5 Remove the `showContactForm` local state and contact branch from `FarmProfile.svelte` and `InitiativeProfile.svelte`; change the contact CTA to `goto(routeBuilders.….contact(id))`; contact back button and successful send `goto` the detail route, keeping the success toast.
+  - [x] 1.6 Update `e2e/contact-drawer.test.ts` for the routed flow (URL hash changes, browser back → detail) and add a deep-link test that loads `#/farms/:id/contact` fresh and sees the form.
 - [ ] 2. Focused-task header for the contact view (depends on: 1)
   - [ ] 2.1 Treat contact as a task level in `MapSidebar.svelte`/`SidebarShell.svelte`: no `SlimSearchHeader` for the contact branch, `focusSearch()` no-ops while contact is open, `shellMode` behaves like `editor` (mobile sheet opens at `full`, collapse forbidden).
   - [ ] 2.2 Add test assertions: contact view renders no search input and exactly one back button (component spec or e2e), and the mobile sheet opens at `full` (extend `e2e/bottom-sheet.test.ts` or the contact e2e); verify list and detail views are unchanged.

--- a/specs/map-next-panel-nav-consistency/plan.md
+++ b/specs/map-next-panel-nav-consistency/plan.md
@@ -11,9 +11,9 @@ Status legend: [ ] todo · [~] in progress · [x] done
   - [x] 1.4 Redirect owners: when the signed-in user can edit the entry (same `canEdit` logic that hides the contact CTA), navigate from the contact route to the entry's detail route.
   - [x] 1.5 Remove the `showContactForm` local state and contact branch from `FarmProfile.svelte` and `InitiativeProfile.svelte`; change the contact CTA to `goto(routeBuilders.….contact(id))`; contact back button and successful send `goto` the detail route, keeping the success toast.
   - [x] 1.6 Update `e2e/contact-drawer.test.ts` for the routed flow (URL hash changes, browser back → detail) and add a deep-link test that loads `#/farms/:id/contact` fresh and sees the form.
-- [ ] 2. Focused-task header for the contact view (depends on: 1)
-  - [ ] 2.1 Treat contact as a task level in `MapSidebar.svelte`/`SidebarShell.svelte`: no `SlimSearchHeader` for the contact branch, `focusSearch()` no-ops while contact is open, `shellMode` behaves like `editor` (mobile sheet opens at `full`, collapse forbidden).
-  - [ ] 2.2 Add test assertions: contact view renders no search input and exactly one back button (component spec or e2e), and the mobile sheet opens at `full` (extend `e2e/bottom-sheet.test.ts` or the contact e2e); verify list and detail views are unchanged.
+- [x] 2. Focused-task header for the contact view (depends on: 1)
+  - [x] 2.1 Treat contact as a task level in `MapSidebar.svelte`/`SidebarShell.svelte`: no `SlimSearchHeader` for the contact branch, `focusSearch()` no-ops while contact is open, `shellMode` behaves like `editor` (mobile sheet opens at `full`, collapse forbidden).
+  - [x] 2.2 Add test assertions: contact view renders no search input and exactly one back button (component spec or e2e), and the mobile sheet opens at `full` (extend `e2e/bottom-sheet.test.ts` or the contact e2e); verify list and detail views are unchanged.
 - [ ] 3. Document the sidebar navigation rule (depends on: none)
   - [ ] 3.1 Add a "Sidebar navigation" subsection under "Code Organization" in `packages/map-next/README.md` stating the rule: browse levels → search + region filters; selected-entry level → pivot search + back (restores pre-detail camera and list scroll) + X (deselects in place); task levels (editors, contact form) → single back button, no search.
   - [ ] 3.2 Update the "focused-task rule" comment in `MapSidebar.svelte` to reference the README section so the comment and doc stay linked.

--- a/specs/map-next-panel-nav-consistency/plan.md
+++ b/specs/map-next-panel-nav-consistency/plan.md
@@ -1,0 +1,19 @@
+# Implementation Plan: Consistent panel navigation for the contact view (map-next)
+
+Spec: specs/map-next-panel-nav-consistency/spec.md
+
+Status legend: [ ] todo · [~] in progress · [x] done
+
+- [ ] 1. Routed contact view (depends on: none)
+  - [ ] 1.1 Add `farm.contact(id)` and `initiative.contact(id)` to `hashRoutes`/`routeBuilders` in `src/lib/utils/routes.ts`, and extend the route parser/matchers (`HashRouteKind` section) to recognize the new paths.
+  - [ ] 1.2 Add loaders `src/routes/farms/[id]/contact/+page.ts` and `src/routes/initiatives/[id]/contact/+page.ts` that reuse the detail loaders via `loadCatching` and return the detail payload under a contact marker (e.g. `contactData`), including the existing `loadError` path.
+  - [ ] 1.3 In `MapSidebar.svelte`, derive the contact mode from `page.data.contactData` in the existing `{#if}` chain and render `EntryContactView` + `EntryContactForm` there; pan/focus the map on the entry the same way the detail branch does (deep-link parity).
+  - [ ] 1.4 Redirect owners: when the signed-in user can edit the entry (same `canEdit` logic that hides the contact CTA), navigate from the contact route to the entry's detail route.
+  - [ ] 1.5 Remove the `showContactForm` local state and contact branch from `FarmProfile.svelte` and `InitiativeProfile.svelte`; change the contact CTA to `goto(routeBuilders.….contact(id))`; contact back button and successful send `goto` the detail route, keeping the success toast.
+  - [ ] 1.6 Update `e2e/contact-drawer.test.ts` for the routed flow (URL hash changes, browser back → detail) and add a deep-link test that loads `#/farms/:id/contact` fresh and sees the form.
+- [ ] 2. Focused-task header for the contact view (depends on: 1)
+  - [ ] 2.1 Treat contact as a task level in `MapSidebar.svelte`/`SidebarShell.svelte`: no `SlimSearchHeader` for the contact branch, `focusSearch()` no-ops while contact is open, `shellMode` behaves like `editor` (mobile sheet opens at `full`, collapse forbidden).
+  - [ ] 2.2 Add test assertions: contact view renders no search input and exactly one back button (component spec or e2e), and the mobile sheet opens at `full` (extend `e2e/bottom-sheet.test.ts` or the contact e2e); verify list and detail views are unchanged.
+- [ ] 3. Document the sidebar navigation rule (depends on: none)
+  - [ ] 3.1 Add a "Sidebar navigation" subsection under "Code Organization" in `packages/map-next/README.md` stating the rule: browse levels → search + region filters; selected-entry level → pivot search + back (restores pre-detail camera and list scroll) + X (deselects in place); task levels (editors, contact form) → single back button, no search.
+  - [ ] 3.2 Update the "focused-task rule" comment in `MapSidebar.svelte` to reference the README section so the comment and doc stay linked.

--- a/specs/map-next-panel-nav-consistency/plan.md
+++ b/specs/map-next-panel-nav-consistency/plan.md
@@ -14,6 +14,6 @@ Status legend: [ ] todo · [~] in progress · [x] done
 - [x] 2. Focused-task header for the contact view (depends on: 1)
   - [x] 2.1 Treat contact as a task level in `MapSidebar.svelte`/`SidebarShell.svelte`: no `SlimSearchHeader` for the contact branch, `focusSearch()` no-ops while contact is open, `shellMode` behaves like `editor` (mobile sheet opens at `full`, collapse forbidden).
   - [x] 2.2 Add test assertions: contact view renders no search input and exactly one back button (component spec or e2e), and the mobile sheet opens at `full` (extend `e2e/bottom-sheet.test.ts` or the contact e2e); verify list and detail views are unchanged.
-- [ ] 3. Document the sidebar navigation rule (depends on: none)
-  - [ ] 3.1 Add a "Sidebar navigation" subsection under "Code Organization" in `packages/map-next/README.md` stating the rule: browse levels → search + region filters; selected-entry level → pivot search + back (restores pre-detail camera and list scroll) + X (deselects in place); task levels (editors, contact form) → single back button, no search.
-  - [ ] 3.2 Update the "focused-task rule" comment in `MapSidebar.svelte` to reference the README section so the comment and doc stay linked.
+- [x] 3. Document the sidebar navigation rule (depends on: none)
+  - [x] 3.1 Add a "Sidebar navigation" subsection under "Code Organization" in `packages/map-next/README.md` stating the rule: browse levels → search + region filters; selected-entry level → pivot search + back (restores pre-detail camera and list scroll) + X (deselects in place); task levels (editors, contact form) → single back button, no search.
+  - [x] 3.2 Update the "focused-task rule" comment in `MapSidebar.svelte` to reference the README section so the comment and doc stay linked.

--- a/specs/map-next-panel-nav-consistency/spec.md
+++ b/specs/map-next-panel-nav-consistency/spec.md
@@ -1,0 +1,131 @@
+# Spec: Consistent panel navigation for the contact view (map-next)
+
+## Problem Statement
+
+The map-next sidebar has three stacked levels: the entry list, the entry detail
+(profile), and the contact form. List and detail behave consistently, but the
+contact view does not:
+
+- It renders **two stacked back buttons** that do different things — the top one
+  (in the slim search header) drops all the way to the list, the inner one (next
+  to the entry name) returns to the profile.
+- It shows the **search bar**, although the contact form is a focused task. Because
+  the form is unrouted local component state, tapping a search suggestion — or the
+  top back arrow — silently discards a half-written message with no confirmation.
+- It has **no route**: browser back from the contact form jumps to the list (the
+  hash never changed while opening the form), breaking the stack model for anyone
+  using the browser back button, and the view is not deep-linkable.
+
+The codebase already has the right principle for focused tasks: the entry editors
+deliberately render no search header ("focused-task rule" in `MapSidebar.svelte`).
+The contact form should follow the same convention. The governing rule, to be
+written down as part of this work:
+
+> **Browse levels get browse tools (search, region filters); the selected-entry
+> level gets pivot search + back + dismiss (X); task levels (forms, editors) get a
+> single back button and nothing else.**
+
+List and detail views stay as they are (search + filters in list; search, back,
+X, and permalink in detail — back restores the pre-detail camera and list scroll,
+X only deselects).
+
+## Features
+
+1. **Routed contact view**
+   - Description: The contact form becomes a hash-routed view instead of local
+     state inside the profile components. New routes `#/farms/:id/contact` and
+     `#/initiatives/:id/contact` (no depot variant — depots resolve to their
+     owning farm's profile). The profile's "contact" CTA navigates to the route;
+     the contact view's back button and a successful send navigate back to the
+     entry detail route.
+   - Acceptance criteria:
+     - Opening the contact form from a farm or initiative profile changes the URL
+       hash to `#/farms/:id/contact` / `#/initiatives/:id/contact`.
+     - Loading that URL directly (fresh page load) shows the contact form for the
+       entry, with the map focused on the entry, same as navigating there by click.
+     - Browser back from the contact view returns to the entry detail view, not
+       the list.
+     - The in-app back button on the contact view returns to the entry detail
+       view; a successful send returns to the detail view and shows the existing
+       success toast.
+     - Deep-linking to the contact route of an entry the signed-in user can edit
+       (owners don't get a contact CTA) redirects to the entry's detail route.
+     - Route builders in `src/lib/utils/routes.ts` cover the new routes; no raw
+       hash strings at call sites.
+
+2. **Focused-task header for the contact view**
+   - Description: The contact view no longer renders the slim search header. It
+     renders exactly one header: back arrow + entry name (the existing
+     `EntryContactView` header), following the editors' focused-task convention.
+   - Acceptance criteria:
+     - The contact view shows no search input and no second back button — exactly
+       one back arrow is visible.
+     - `focusSearch()` (e.g. keyboard shortcut) is a no-op while the contact view
+       is open, matching editor behavior.
+     - On mobile, the contact view opens the bottom sheet at `full` and stays
+       expanded, matching editor behavior (a form needs the space; it is a
+       focused task, not a browse level).
+     - The list and detail views are visually and behaviorally unchanged (list:
+       search + filters; detail: slim search header with back, plus permalink and
+       X in the profile header; back still restores pre-detail camera and list
+       scroll, X still only deselects).
+
+3. **Document the sidebar navigation rule**
+   - Description: Write the summary rule down where future contributors will see
+     it: a short "Sidebar navigation" subsection in `packages/map-next/README.md`
+     (under "Code Organization"), stating the three levels, which tools each level
+     gets, and the back-vs-X semantics on the detail level. Reference it from the
+     existing "focused-task rule" comment in `MapSidebar.svelte` so the code
+     comment and the doc don't drift apart.
+   - Acceptance criteria:
+     - `packages/map-next/README.md` contains the rule: browse levels → search +
+       filters; selected-entry level → pivot search + back (restores context) +
+       X (deselects in place); task levels → single back button, no search.
+     - The `MapSidebar.svelte` focused-task comment points to that README section.
+
+## Technical Solution
+
+- Architecture: Follow the existing hash-route pattern. New SvelteKit routes
+  `src/routes/farms/[id]/contact/+page.ts` and
+  `src/routes/initiatives/[id]/contact/+page.ts` reuse the detail loaders (wrap in
+  `loadCatching` like the others) and return the detail payload plus a marker
+  (e.g. `contactData`). `MapSidebar.svelte` derives the contact mode from route
+  data in its existing `{#if}` chain and renders `EntryContactView` +
+  `EntryContactForm` directly — `FarmProfile`/`InitiativeProfile` drop their
+  `showContactForm` local state and contact branch; their CTA becomes a `goto` to
+  the new route. `shellMode` treats contact like `editor` (no search header,
+  mobile sheet at `full`, collapse forbidden).
+- Technologies: no new ones — Svelte 5 / SvelteKit hash router, existing
+  `routeBuilders`, existing components.
+- Key decisions:
+  - Contact is classified as a **task level** (like editors), not a detail
+    sub-view — that single decision drives header, search, mobile snap, and
+    keyboard behavior. Alternative (keep slim search header, remove only the
+    inner back) was rejected: search-away from a dirty form is silent data loss.
+  - No "discard message?" confirmation dialog: with the search header gone, the
+    only in-app exit is the deliberate back button; browser back is likewise
+    deliberate. Revisit only if users report draft loss.
+  - Owner deep-link redirects to detail rather than rendering the form, matching
+    the existing rule that owners see edit affordances instead of a contact CTA.
+  - Error states for the contact routes reuse the existing `loadError` →
+    `ErrorState` path.
+
+## Out of Scope
+
+- Any changes to list or detail view layout, headers, or the back/X semantics.
+- Draft persistence for the contact form (surviving reload or navigation).
+- A dirty-form discard confirmation dialog.
+- Contact routes for depots or locations.
+- Legacy-route aliases (there is no legacy contact URL to map).
+
+## Additional Notes
+
+- Existing e2e coverage to update/extend: `e2e/contact-drawer.test.ts` (flow now
+  crosses routes), plus a new assertion in `e2e/legacy-routes.test.ts`-style
+  deep-link tests for the contact routes if that's where deep-link coverage
+  lives.
+- The contact form component (`EntryContactForm.svelte`) and the send API are
+  unchanged; only mounting and navigation move.
+- Assumption: unauthenticated visitors can use the contact form today (no
+  sign-in gate); the routed view keeps whatever gating currently exists — this
+  spec does not change access rules.

--- a/specs/map-next-panel-nav-consistency/spec.md
+++ b/specs/map-next-panel-nav-consistency/spec.md
@@ -93,8 +93,9 @@ X only deselects).
   data in its existing `{#if}` chain and renders `EntryContactView` +
   `EntryContactForm` directly — `FarmProfile`/`InitiativeProfile` drop their
   `showContactForm` local state and contact branch; their CTA becomes a `goto` to
-  the new route. `shellMode` treats contact like `editor` (no search header,
-  mobile sheet at `full`, collapse forbidden).
+  the new route. shellMode treats contact as a task level — full mobile sheet,
+  collapse forbidden, near-full-height desktop insets — but keeps the standard
+  sidebar width; only editors widen the desktop drawer.
 - Technologies: no new ones — Svelte 5 / SvelteKit hash router, existing
   `routeBuilders`, existing components.
 - Key decisions:


### PR DESCRIPTION
The sidebar contact form is now a hash-routed view (`#/farms/:id/contact`, `#/initiatives/:id/contact`) instead of local state inside `FarmProfile`/`InitiativeProfile`, so it is deep-linkable and browser-back returns to the entry detail rather than the list; owners deep-linking to it are redirected to the detail route, and the view waits for session init so prefill matches the click path.

It is now treated as a **task level** like the entry editors: no slim search header, exactly one back button, `focusSearch()` no-ops, and the mobile sheet opens at `full` and cannot be collapsed — which removes the previous silent discard of a half-written message when tapping a search suggestion. `SidebarShell` gained a distinct `task` mode for this, sharing the editor's snap/collapse/height behavior but keeping the standard 500px desktop width (reusing `editor` verbatim would have jumped the drawer to 680px and desynced `Map.svelte`'s map-focus offset).

The governing rule is written down in a new "Sidebar navigation" section of `packages/map-next/README.md` (browse levels → search + filters; selected-entry level → pivot search + back + X; task levels → single back button), referenced from the focused-task comment in `MapSidebar.svelte`.

Verified: `npm run check` 0 errors, `npm run lint` clean, 107 unit tests pass, and the `contact-drawer`, `bottom-sheet`, `responsive-shell-footer` and `inline-edit-create` e2e suites pass. Spec and plan for this work are in `specs/map-next-panel-nav-consistency/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)