### PR TITLE
fix(map-next): keep the editor form's overflow inside the sidebar drawer

### DIFF
--- a/packages/map-next/e2e/inline-edit-create.test.ts
+++ b/packages/map-next/e2e/inline-edit-create.test.ts
@@ -498,3 +498,41 @@ test('detail drawer is near-full-height and the editor drawer is wider on lg des
 	// Map stays visible beside the wider editor (drawer doesn't span the viewport).
 	expect(editorBox!.x + editorBox!.width).toBeLessThan(1280);
 });
+
+test('long editor form scrolls inside the drawer without scrolling the app out of the viewport', async ({
+	page
+}) => {
+	await mockAuthenticatedUser(page);
+	await mockEditorCatalogs(page);
+	await mockOwnedEntriesAndDetails(page);
+	await page.setViewportSize({ width: 1280, height: 900 });
+
+	await page.goto('/#/farms/farm-owned/edit');
+	await expect(page.getByTestId('entry-editor')).toBeVisible({ timeout: 15000 });
+
+	// The form is taller than the drawer, but its scrollable overflow must stay
+	// inside the drawer's scroll container — the document itself never scrolls.
+	const metrics = await page.evaluate(() => {
+		const content = document.querySelector('[data-slot="sidebar-content"]');
+		return {
+			documentScrollHeight: document.documentElement.scrollHeight,
+			viewportHeight: document.documentElement.clientHeight,
+			contentScrollHeight: content?.scrollHeight ?? 0,
+			contentHeight: content?.clientHeight ?? 0
+		};
+	});
+	expect(metrics.contentScrollHeight).toBeGreaterThan(metrics.contentHeight);
+	expect(metrics.documentScrollHeight).toBe(metrics.viewportHeight);
+
+	// Wheeling past the end of the form must not chain to the document.
+	await page.mouse.move(200, 500);
+	for (let i = 0; i < 40; i++) {
+		await page.mouse.wheel(0, 200);
+	}
+	await expect
+		.poll(() =>
+			page.evaluate(() => document.querySelector('[data-slot="sidebar-content"]')!.scrollTop)
+		)
+		.toBeGreaterThan(0);
+	expect(await page.evaluate(() => window.scrollY)).toBe(0);
+});

--- a/packages/map-next/playwright.reuse.config.ts
+++ b/packages/map-next/playwright.reuse.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+/*
+ * The default config builds the app inside Playwright's 60s webServer timeout,
+ * which the build regularly exceeds locally — every test then fails with errors
+ * that look like app bugs. This config skips the build and reuses a running
+ * preview server: `npm run build`, then `npm run preview -- --port 4173`, then
+ * `npx playwright test --config ./playwright.reuse.config.ts`.
+ */
+export default defineConfig({
+	webServer: { command: 'npm run preview -- --port 4173', port: 4173, reuseExistingServer: true },
+	testDir: 'e2e',
+	use: { baseURL: 'http://localhost:4173' }
+});

--- a/packages/map-next/src/lib/components/domain/depots/DepotEditor.svelte
+++ b/packages/map-next/src/lib/components/domain/depots/DepotEditor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
+	import { SidebarScrollArea } from '$lib/components/layout';
 	import * as Field from '$lib/components/ui/field';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Paragraph } from '$lib/components/typography';
@@ -166,7 +167,7 @@
 	<h2 class="text-lg font-semibold">{title}</h2>
 </Sidebar.Header>
 
-<Sidebar.Content class="overflow-y-auto">
+<SidebarScrollArea>
 	<form
 		class="flex flex-col gap-4 p-4 pb-24"
 		data-testid="depot-editor"
@@ -264,4 +265,4 @@
 
 		<EditorSaveBar {isSaving} testIdPrefix="depot-editor" onCancel={() => void handleCancel()} />
 	</form>
-</Sidebar.Content>
+</SidebarScrollArea>

--- a/packages/map-next/src/lib/components/domain/entries/EntryContactView.svelte
+++ b/packages/map-next/src/lib/components/domain/entries/EntryContactView.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left';
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
+	import { SidebarScrollArea } from '$lib/components/layout';
 	import { IconButton } from '$lib/components/actions';
 	import EntryContactForm from './EntryContactForm.svelte';
 	import { toastSuccess } from '$lib/utils/toast';
@@ -52,8 +53,8 @@
 	</div>
 </Sidebar.Header>
 
-<Sidebar.Content class="overflow-y-auto">
+<SidebarScrollArea>
 	<div class="p-4">
 		<EntryContactForm {entryId} {entryType} {initialName} {initialEmail} onSent={handleSent} />
 	</div>
-</Sidebar.Content>
+</SidebarScrollArea>

--- a/packages/map-next/src/lib/components/domain/farms/FarmProfile.svelte
+++ b/packages/map-next/src/lib/components/domain/farms/FarmProfile.svelte
@@ -5,6 +5,7 @@
 	import { defaults, superForm } from 'sveltekit-superforms';
 	import { zod4, zod4Client } from 'sveltekit-superforms/adapters';
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
+	import { SidebarScrollArea } from '$lib/components/layout';
 	import { AppButton, IconButton } from '$lib/components/actions';
 	import { Paragraph } from '$lib/components/typography';
 	import { EditorAccountInfo, EditorSaveBar } from '$lib/components/forms';
@@ -268,7 +269,7 @@
 		</div>
 	</Sidebar.Header>
 
-	<Sidebar.Content class="overflow-y-auto">
+	<SidebarScrollArea>
 		{#if mode === 'edit'}
 			<form class="flex flex-col p-4 pb-24" data-testid="entry-editor" onsubmit={handleFormSubmit}>
 				<Paragraph size="small" class="pb-6">{m.user_form_required_fields()}</Paragraph>
@@ -318,7 +319,7 @@
 				/>
 			</div>
 		{/if}
-	</Sidebar.Content>
+	</SidebarScrollArea>
 
 	<!-- Feature 5.3: the CTA is hidden on entries the current account owns
 	     (`canEdit`), who edit rather than contact themselves. -->

--- a/packages/map-next/src/lib/components/domain/initiatives/InitiativeProfile.svelte
+++ b/packages/map-next/src/lib/components/domain/initiatives/InitiativeProfile.svelte
@@ -5,6 +5,7 @@
 	import { defaults, superForm } from 'sveltekit-superforms';
 	import { zod4, zod4Client } from 'sveltekit-superforms/adapters';
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
+	import { SidebarScrollArea } from '$lib/components/layout';
 	import { AppButton, IconButton } from '$lib/components/actions';
 	import { Paragraph } from '$lib/components/typography';
 	import { EditorAccountInfo, EditorSaveBar } from '$lib/components/forms';
@@ -245,7 +246,7 @@
 		</div>
 	</Sidebar.Header>
 
-	<Sidebar.Content class="overflow-y-auto">
+	<SidebarScrollArea>
 		{#if mode === 'edit'}
 			<form class="flex flex-col p-4 pb-24" data-testid="entry-editor" onsubmit={handleFormSubmit}>
 				<Paragraph size="small" class="pb-1">{m.user_form_required_fields()}</Paragraph>
@@ -274,7 +275,7 @@
 				<BadgesSection mode="read" {properties} {form} idPrefix="initiative-badge" />
 			</div>
 		{/if}
-	</Sidebar.Content>
+	</SidebarScrollArea>
 
 	<!-- Feature 5.3: the CTA is hidden on entries the current account owns
 	     (`canEdit`), who edit rather than contact themselves. -->

--- a/packages/map-next/src/lib/components/layout/SidebarScrollArea.svelte
+++ b/packages/map-next/src/lib/components/layout/SidebarScrollArea.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
+
+	interface Props {
+		/** Bound by callers that read or restore the scroll position. */
+		ref?: HTMLElement | null;
+		children: Snippet;
+	}
+
+	let { ref = $bindable(null), children }: Props = $props();
+</script>
+
+<!--
+	`relative` makes this the containing block for absolutely positioned
+	descendants. Without it they resolve against the positioned sidebar shell
+	outside the scroller, so `overflow` never clips them and their scrollable
+	overflow escapes to the document — a long editor form's `sr-only` fieldset
+	legends made the whole page scrollable and scrolled the map out of the viewport.
+-->
+<Sidebar.Content bind:ref class="relative overflow-y-auto">
+	{@render children()}
+</Sidebar.Content>

--- a/packages/map-next/src/lib/components/layout/index.ts
+++ b/packages/map-next/src/lib/components/layout/index.ts
@@ -3,6 +3,7 @@ import AuthDialog from './AuthDialog.svelte';
 import BottomSheet from './BottomSheet.svelte';
 import ConfirmDialog from './ConfirmDialog.svelte';
 import ErrorState from './ErrorState.svelte';
+import SidebarScrollArea from './SidebarScrollArea.svelte';
 import SidebarShell from './SidebarShell.svelte';
 import TwoColumnLayout from './TwoColumnLayout.svelte';
 import UserNavigation from './UserNavigation.svelte';
@@ -13,6 +14,7 @@ export {
 	BottomSheet,
 	ConfirmDialog,
 	ErrorState,
+	SidebarScrollArea,
 	SidebarShell,
 	TwoColumnLayout,
 	UserNavigation

--- a/packages/map-next/src/lib/components/ui/sidebar/sidebar-content.svelte
+++ b/packages/map-next/src/lib/components/ui/sidebar/sidebar-content.svelte
@@ -15,7 +15,7 @@
 	data-slot="sidebar-content"
 	data-sidebar="content"
 	class={cn(
-		'relative no-scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-auto [--radius:var(--radius-xl)] group-data-[collapsible=icon]:overflow-hidden',
+		'no-scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-auto [--radius:var(--radius-xl)] group-data-[collapsible=icon]:overflow-hidden',
 		className
 	)}
 	{...restProps}

--- a/packages/map-next/src/lib/components/ui/sidebar/sidebar-content.svelte
+++ b/packages/map-next/src/lib/components/ui/sidebar/sidebar-content.svelte
@@ -15,7 +15,7 @@
 	data-slot="sidebar-content"
 	data-sidebar="content"
 	class={cn(
-		'no-scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-auto [--radius:var(--radius-xl)] group-data-[collapsible=icon]:overflow-hidden',
+		'relative no-scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-auto [--radius:var(--radius-xl)] group-data-[collapsible=icon]:overflow-hidden',
 		className
 	)}
 	{...restProps}

--- a/packages/map-next/src/routes/MapSidebar.svelte
+++ b/packages/map-next/src/routes/MapSidebar.svelte
@@ -4,9 +4,8 @@
 	import { SvelteSet } from 'svelte/reactivity';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { confirmDialog } from '$lib/stores/confirm-dialog.svelte';
-	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
 	import { IsMobile } from '$lib/hooks/is-mobile.svelte';
-	import { ErrorState, SidebarShell } from '$lib/components/layout';
+	import { ErrorState, SidebarScrollArea, SidebarShell } from '$lib/components/layout';
 	import config from '$lib/config/app-configuration';
 	import type {
 		DepotFeature,
@@ -932,7 +931,7 @@
 			onStateSelect={handleStateSelect}
 		/>
 		{#if !effectiveCollapsed}
-			<Sidebar.Content bind:ref={listScrollEl} class="overflow-y-auto">
+			<SidebarScrollArea bind:ref={listScrollEl}>
 				{#if isMyEntriesScope}
 					<MyEntriesCreateActions onCreate={handleCreateEntry} />
 					<MyEntriesList
@@ -959,7 +958,7 @@
 						{onResetView}
 					/>
 				{/if}
-			</Sidebar.Content>
+			</SidebarScrollArea>
 		{/if}
 	{/if}
 </SidebarShell>


### PR DESCRIPTION
Opening the entry editor and scrolling the form scrolled the entire app — map included — out of the viewport, leaving a white gap below.

The sidebar scroll container (`Sidebar.Content`) was `position: static`, so it was not the containing block for its absolutely positioned descendants; those resolved against the positioned shell outside the scroller and `overflow` never clipped them. The editor's `sr-only` fieldset legends (which are `position: absolute`) escaped that way and pushed their scrollable overflow onto the document — measured at `document.scrollHeight` 2355 vs a 900px viewport, matching the deepest escaped legend exactly. Read mode was unaffected only because it renders no fieldsets.

Adding `relative` to the scroll container fixes every drawer surface (profiles, editors, depot editor, contact view, entry list) on desktop and mobile, plus an e2e regression test asserting the document never scrolls while a long editor form does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)