### PR TITLE
fix(map-next): frame depot-backed farms on a contact deep link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,11 @@ config.json
 # testing
 /coverage
 
+# Playwright writes this relative to where it is invoked, so running the map-next
+# e2e suite from the repo root leaves an unignored dir that breaks pre-push.
+# packages/map-next/.gitignore only covers runs started inside that package.
+test-results
+
 # production
 build
 

--- a/packages/map-next/e2e/contact-drawer.test.ts
+++ b/packages/map-next/e2e/contact-drawer.test.ts
@@ -51,6 +51,64 @@ function ownedFarmMarker(id: string, name: string) {
 	};
 }
 
+// A farm with depots is framed by the map's network `fitBounds` instead of the
+// plain focusEntry flyTo. Depot and farm sit close together so the fit lands at a
+// zoom where individual symbol markers render (they appear from 9.5; the initial
+// view is zoom 6).
+const NETWORK_DEPOT_COORDS = [10.4515, 51.1657];
+const NETWORK_FARM_COORDS = [10.44, 51.155];
+
+function networkFarmMarker(id: string, name: string) {
+	return {
+		type: 'Feature',
+		geometry: { type: 'Point', coordinates: NETWORK_FARM_COORDS },
+		properties: {
+			id,
+			type: 'Farm',
+			name,
+			postalcode: '00000',
+			city: 'Center',
+			state: 'DE',
+			country: 'DE',
+			link: 'https://example.com',
+			products: []
+		}
+	};
+}
+
+function farmDetailWithDepot(id: string, name: string) {
+	return {
+		type: 'Feature',
+		geometry: { type: 'Point', coordinates: NETWORK_FARM_COORDS },
+		properties: {
+			...farmDetail(id, name).properties,
+			city: 'Center',
+			postalcode: '00000',
+			state: 'DE',
+			country: 'DE',
+			depots: {
+				type: 'FeatureCollection',
+				features: [
+					{
+						type: 'Feature',
+						geometry: { type: 'Point', coordinates: NETWORK_DEPOT_COORDS },
+						properties: {
+							id: 'depot-1',
+							type: 'Depot',
+							name: 'Depot One',
+							city: 'Center',
+							postalcode: '00000',
+							state: 'DE',
+							country: 'DE',
+							link: 'https://example.com'
+						}
+					}
+				]
+			}
+		}
+	};
+}
+
 async function mockAuthenticatedUser(page: Page) {
 	await page.addInitScript(() => {
 		window.localStorage.setItem('accessToken', 'test-token');
@@ -143,6 +201,34 @@ test('a contact deep link opens the form and browser back returns to the profile
 	await expect.poll(() => page.url(), { timeout: 15000 }).toMatch(/#\/farms\/public-farm$/);
 	await expect(page.getByTestId('entry-contact-form')).toBeHidden();
 	await expect(page.getByTestId('entry-contact-toggle')).toBeVisible();
+});
+
+test('a contact deep link frames a farm that has depots', async ({ page }) => {
+	await mockAuthenticatedUser(page);
+	await page.route(/\/entries(?:\/)?(?:\?.*)?$/, (route) => {
+		const url = new URL(route.request().url());
+		if (url.searchParams.get('mine') === 'true') {
+			return fulfillJson(route, { type: 'FeatureCollection', features: [] });
+		}
+		return fulfillJson(route, {
+			type: 'FeatureCollection',
+			features: [networkFarmMarker('network-farm', 'Network Farm')]
+		});
+	});
+	await page.route(/\/farms\/[^/?]+(?:\?.*)?$/, (route) =>
+		fulfillJson(route, farmDetailWithDepot('network-farm', 'Network Farm'))
+	);
+
+	await page.goto('/#/farms/network-farm/contact');
+	await expect(page.getByTestId('entry-contact-form')).toBeVisible({ timeout: 15000 });
+
+	// The network camera is owned by the fitBounds effect, which reads the open
+	// entry — the contact route has to feed it, or the map stays at the initial
+	// country view. Symbol markers only render from zoom 9.5, so a highlighted
+	// marker on screen means the fit ran for the contact deep link too.
+	const highlightedMarker = page.locator('.marker-button--highlighted').first();
+	await expect(highlightedMarker).toBeVisible({ timeout: 15000 });
+	await expect(highlightedMarker).toBeInViewport();
 });
 
 test('a contact deep link for an owned entry redirects to its profile', async ({ page }) => {

--- a/packages/map-next/src/routes/Map.svelte
+++ b/packages/map-next/src/routes/Map.svelte
@@ -142,7 +142,16 @@
 	// entry itself is highlighted; a farm's depot lines/highlights additionally
 	// appear when it has depots.
 	const detailData = $derived(page.data.detailData);
-	const networkEntry = $derived<MainEntryFeature | null>(detailData ?? null);
+	// The contact route frames its entry exactly like the detail route (see
+	// `focusedEntry` in MapSidebar), so everything the map hangs off "an entry is
+	// open" — network layer, marker selection, pre-detail camera — reads this
+	// rather than `detailData` alone. Without it a contact deep link for a farm
+	// with depots would never move the map: focusEntry defers network farms to the
+	// fitBounds effect below, which would find nothing to fit.
+	const focusedEntryData = $derived<MainEntryFeature | undefined>(
+		detailData ?? page.data.contactData
+	);
+	const networkEntry = $derived<MainEntryFeature | null>(focusedEntryData ?? null);
 	// The subset of the above that's a farm with depots, used to drive the
 	// network fitBounds camera (initiatives and depot-less farms have no network
 	// to fit, so they fall back to the plain focusEntry flyTo instead).
@@ -157,7 +166,9 @@
 	});
 	// Hover key of the entry whose profile is open, so its marker stays visually
 	// selected until the profile closes (spec F13).
-	const selectedEntryKey = $derived(detailData ? entryHoverKey(detailData.properties) : null);
+	const selectedEntryKey = $derived(
+		focusedEntryData ? entryHoverKey(focusedEntryData.properties) : null
+	);
 	const highlightedNetworkIds = $derived.by<SvelteSet<string>>(() => {
 		const ids = new SvelteSet<string>();
 		if (networkEntry) {
@@ -317,7 +328,7 @@
 	function focusEntry(feature: EntryFeature, options?: EntryFocusOptions) {
 		// Opening a detail from the map/list (no detail open yet) is the moment to
 		// remember the current viewport, before the fly-to reframes it (F12.3).
-		if (!detailData) {
+		if (!focusedEntryData) {
 			snapshotPreDetailCamera();
 		}
 
@@ -523,8 +534,8 @@
 			// detail reached by a route-only path (search suggestion, deep link after
 			// browsing) — which never runs focusEntry before navigation — can still
 			// restore the previous viewport on Back (F12.3). The detail-open fly-to
-			// settles with detailData already set, so it does not overwrite this.
-			if (!detailData) {
+			// settles with the entry already set, so it does not overwrite this.
+			if (!focusedEntryData) {
 				snapshotPreDetailCamera();
 			}
 		};
@@ -540,13 +551,13 @@
 	});
 
 	// Capture the initial browsing camera once the map is ready, so a search-opened
-	// detail with no prior map movement can still restore on Back. Reads detailData
+	// detail with no prior map movement can still restore on Back. Reads the entry
 	// untracked so this fires once (on map init), not on every detail change.
 	let didCaptureInitialCamera = false;
 	$effect(() => {
 		if (!map || didCaptureInitialCamera) return;
 		didCaptureInitialCamera = true;
-		if (!untrack(() => detailData)) {
+		if (!untrack(() => focusedEntryData)) {
 			snapshotPreDetailCamera();
 		}
 	});


### PR DESCRIPTION
Follow-up to #891, addressing a review finding that landed after that PR was merged.

`Map.svelte` derived the network layer, the selected-marker key and the pre-detail camera guards from `page.data.detailData` alone. The contact loaders deliberately return `contactData` instead, so a deep link to `#/farms/:id/contact` for a farm that has depots never moved the map: `focusEntry` defers network farms to the `fitBounds` effect, and that effect found nothing to fit. Feature 1's acceptance criteria already required the map to frame the entry on a contact deep link, so this is a gap in that work rather than a new behaviour.

The fix is a single `focusedEntryData = detailData ?? contactData` derived — mirroring `focusedEntry` in `MapSidebar` — read everywhere the map hangs off "an entry is open". Beyond the camera it also keeps the depot lines and the selected marker rendered across detail↔contact, and stops the `moveend` handler from overwriting the pre-detail camera snapshot with the framed one on a contact deep link. Detail routes are unaffected: for them `focusedEntryData === detailData`.

Also adds `test-results` to the root `.gitignore`. Playwright writes it relative to the invocation directory and `packages/map-next/.gitignore` only covers runs started inside that package, so running the e2e suite from the repo root left an unignored dir that failed the `pre-push` prettier check.

The new e2e case in `contact-drawer.test.ts` fails on the pre-fix tree — symbol markers only render from zoom 9.5 while the initial view is zoom 6, so a highlighted marker on screen proves the fit actually ran. Verified: `npm run check` 0 errors, 107 unit tests pass, `contact-drawer` (6), `network-visualization`, `detail-profile-polish` and `depot-on-profile` pass per file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)