### PR TITLE
fix(map-next): raise the sidebar focus ring to 3:1

### DIFF
--- a/packages/map-next/src/lib/design/theme-vars.css
+++ b/packages/map-next/src/lib/design/theme-vars.css
@@ -136,7 +136,11 @@
 	--sidebar-accent: var(--base-color-olive-100);
 	--sidebar-accent-foreground: var(--base-color-olive-900);
 	--sidebar-border: var(--base-color-olive-200);
-	--sidebar-ring: var(--base-color-olive-400);
+	/* Focus ring for sidebar rows, which set outline-hidden — this is their only
+	   focus indicator, so it needs ≥3:1 (WCAG 2.2 SC 1.4.11) against both the cream
+	   --sidebar and the white --card. olive-400 measured 2.04:1 on cream; olive-600
+	   (the --control-border altitude) measures 3.734:1 / 4.260:1. */
+	--sidebar-ring: var(--base-color-olive-600);
 }
 
 [data-theme='client-demo'],

--- a/specs/map-next-entry-list-a11y/plan.md
+++ b/specs/map-next-entry-list-a11y/plan.md
@@ -67,13 +67,13 @@ under `src/lib/components/ui/` is modified.
         identical full-row fill (not the inset card), and that the list still auto-scrolls the
         matching row into view for map-sourced hovers only.
 
-- [ ] 5. Focus ring meets 3:1 (depends on: none)
-  - [ ] 5.1 Repoint the `teikei` theme's `--sidebar-ring` from `--base-color-olive-400` to
+- [x] 5. Focus ring meets 3:1 (depends on: none)
+  - [x] 5.1 Repoint the `teikei` theme's `--sidebar-ring` from `--base-color-olive-400` to
         `--base-color-olive-600` in `src/lib/design/theme-vars.css`; leave `client-demo`
         (brand-700) alone.
-  - [ ] 5.2 Verify `--sidebar-ring` measures ≥3:1 against both `--sidebar` and `--card` in
+  - [x] 5.2 Verify `--sidebar-ring` measures ≥3:1 against both `--sidebar` and `--card` in
         every theme (expected 3.734:1 and 4.260:1 for teikei).
-  - [ ] 5.3 Tab to an entry row and confirm the ring is clearly visible against the cream panel.
+  - [x] 5.3 Tab to an entry row and confirm the ring is clearly visible against the cream panel.
 
 - [ ] 6. Keyboard focus drives the map highlight (public list only) (depends on: 1)
   - [ ] 6.1 Add `onfocus` → `hoveredEntry.setHover(props, 'list')` and `onblur` →


### PR DESCRIPTION
Implements Feature 5 of `specs/map-next-entry-list-a11y` (task 5.1–5.3).

The entry rows in the map sidebar set `outline-hidden`, so `--sidebar-ring` is their only focus indicator — and at olive-400 it measured 2.04:1 against the cream `--sidebar`, below the 3:1 that WCAG 2.2 SC 1.4.11 requires. This repoints the `teikei` theme's `--sidebar-ring` to `--base-color-olive-600` (the same altitude as `--control-border`); `client-demo` already passed at brand-700 and is untouched.

## Verification

Contrast recomputed from the oklch token values (oklch → linear sRGB → WCAG relative luminance), matching the spec's figures exactly:

| | vs `--sidebar` | vs `--card` |
|---|---|---|
| teikei olive-600 (new) | **3.734:1** | **4.260:1** |
| teikei olive-400 (old) | 2.037:1 | — |
| client-demo brand-700 | 7.782:1 | 8.125:1 |

Confirmed the token actually reaches the row (`sidebar-menu-button.svelte` carries `ring-sidebar-ring focus-visible:ring-2 outline-hidden`, mapped at `src/routes/layout.css:95`), and verified in the running app with a throwaway Playwright spec: a focused row computes `oklch(0.58 0.031 107.3)` painted as `0 0 0 2px`, clearly visible against the cream panel. The temp spec was deleted; `prettier --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)