### PR TITLE
fix(map-next): hide entry-list loading skeletons from assistive tech

### DIFF
--- a/packages/map-next/e2e/perf-accessibility-sanity.test.ts
+++ b/packages/map-next/e2e/perf-accessibility-sanity.test.ts
@@ -30,6 +30,19 @@ async function mockLargeEntries(page: Page) {
 	);
 }
 
+async function mockAuthenticatedUser(page: Page) {
+	await page.addInitScript(() => {
+		window.localStorage.setItem('accessToken', 'test-token');
+	});
+
+	await page.route(/\/authentication(?:\/)?(?:\?.*)?$/, (route) =>
+		fulfillJson(route, {
+			accessToken: 'test-token',
+			user: { id: 'user-1', email: 'owner@example.com', name: 'Owner User' }
+		})
+	);
+}
+
 test('sidebar caps rendered rows for large all-entries lists and exposes cap indicator', async ({
 	page
 }) => {
@@ -49,4 +62,26 @@ test('sidebar interactive controls expose accessible labels', async ({ page }) =
 
 	await expect(page.getByTestId('sidebar-collapse-toggle')).toHaveAttribute('aria-label', /.+/);
 	await expect(page.locator('input[aria-label]').first()).toHaveAttribute('aria-label', /.+/);
+});
+
+test('loading skeleton rows are hidden from the accessibility tree while aria-busy stays set', async ({
+	page
+}) => {
+	await mockAuthenticatedUser(page);
+	await page.route(/\/entries(?:\/)?(?:\?.*)?$/, (route) => {
+		// The my-entries request is left hanging so the list stays in its loading
+		// state for the duration of the test and the skeleton rows can be inspected.
+		if (new URL(route.request().url()).searchParams.get('mine') === 'true') {
+			return;
+		}
+		return fulfillJson(route, { type: 'FeatureCollection', features: [] });
+	});
+
+	await page.goto('/#/myentries');
+
+	const list = page.getByTestId('entries-list');
+	await expect(list).toHaveAttribute('aria-busy', 'true', { timeout: 15000 });
+	await expect(page.getByTestId('entry-skeleton')).toHaveCount(5);
+
+	await expect(list.getByRole('listitem')).toHaveCount(0);
 });

--- a/packages/map-next/src/lib/components/domain/entries/EntriesList.svelte
+++ b/packages/map-next/src/lib/components/domain/entries/EntriesList.svelte
@@ -80,7 +80,7 @@
 		>
 			{#if showSkeleton}
 				{#each Array.from({ length: SKELETON_ROW_COUNT }) as _, index (index)}
-					<Sidebar.MenuItem data-testid="entry-skeleton">
+					<Sidebar.MenuItem data-testid="entry-skeleton" aria-hidden="true">
 						<div class="flex items-start gap-3 px-2 py-3">
 							<Skeleton class="size-9 shrink-0 rounded-full" />
 							<div class="flex min-w-0 flex-1 flex-col gap-2">

--- a/packages/map-next/src/lib/components/domain/entries/MyEntriesList.svelte
+++ b/packages/map-next/src/lib/components/domain/entries/MyEntriesList.svelte
@@ -150,7 +150,7 @@
 		{#if showSkeleton}
 			<Sidebar.Menu data-testid="entries-list" aria-busy="true">
 				{#each Array.from({ length: SKELETON_ROW_COUNT }) as _, index (index)}
-					<Sidebar.MenuItem data-testid="entry-skeleton">
+					<Sidebar.MenuItem data-testid="entry-skeleton" aria-hidden="true">
 						<div class="flex items-start gap-3 px-2 py-3">
 							<Skeleton class="size-9 shrink-0 rounded-full" />
 							<div class="flex min-w-0 flex-1 flex-col gap-2">

--- a/specs/map-next-entry-list-a11y/plan.md
+++ b/specs/map-next-entry-list-a11y/plan.md
@@ -84,11 +84,11 @@ under `src/lib/components/ui/` is modified.
         guarded to `source === 'map'`).
   - [ ] 6.3 Confirm `MyEntriesList.svelte` is untouched — no hover or focus coupling added.
 
-- [ ] 7. Loading skeletons hidden from assistive technology (depends on: none)
-  - [ ] 7.1 Add `aria-hidden="true"` to the skeleton `Sidebar.MenuItem`s in
+- [x] 7. Loading skeletons hidden from assistive technology (depends on: none)
+  - [x] 7.1 Add `aria-hidden="true"` to the skeleton `Sidebar.MenuItem`s in
         `EntriesList.svelte` (passed through `restProps`).
-  - [ ] 7.2 Same for the skeleton `Sidebar.MenuItem`s in `MyEntriesList.svelte`.
-  - [ ] 7.3 Verify the accessibility tree exposes no empty list items while loading, and that
+  - [x] 7.2 Same for the skeleton `Sidebar.MenuItem`s in `MyEntriesList.svelte`.
+  - [x] 7.3 Verify the accessibility tree exposes no empty list items while loading, and that
         `aria-busy` on the `<ul>` is retained; add e2e coverage in
         `e2e/perf-accessibility-sanity.test.ts`.
 


### PR DESCRIPTION
Implements feature 7 of `specs/map-next-entry-list-a11y`: the skeleton placeholders in both entry lists were real `<li>`s with no text, so a screen reader announced five empty list items while loading. They now carry `aria-hidden="true"` (passed through `Sidebar.MenuItem`'s `restProps`), leaving `aria-busy` on the `<ul>` as the loading signal — no file under `src/lib/components/ui/` is touched. New e2e coverage in `e2e/perf-accessibility-sanity.test.ts` holds the my-entries list in its loading state and asserts the list exposes zero `listitem` roles while `aria-busy="true"` and five skeleton rows are present.

Verified: `npm run check` clean (0 errors), all 8 tests in `perf-accessibility-sanity.test.ts` + `my-entries-scope.test.ts` pass, and the new test was confirmed non-vacuous (it fails with `Expected 0, Received 5` when the `aria-hidden` is removed). Note for reviewers: `EntriesList`'s skeleton branch is unreachable in practice — `showSkeleton` requires `isMyEntriesScope`, but `MapSidebar.svelte:988` renders `MyEntriesList` in that case — so only `MyEntriesList`'s skeleton is exercisable; the spec asks for both files, and the dead path is pre-existing debt worth a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)