### PR TITLE
feat(map-next): give the entry lists an accessible name

### DIFF
--- a/packages/map-next/e2e/perf-accessibility-sanity.test.ts
+++ b/packages/map-next/e2e/perf-accessibility-sanity.test.ts
@@ -8,8 +8,8 @@ async function fulfillJson(route: Route, body: unknown) {
 	});
 }
 
-async function mockLargeEntries(page: Page) {
-	const features = Array.from({ length: 250 }, (_, index) => ({
+async function mockLargeEntries(page: Page, count = 250) {
+	const features = Array.from({ length: count }, (_, index) => ({
 		type: 'Feature' as const,
 		geometry: { type: 'Point' as const, coordinates: [10.0 + index * 0.001, 51.0] },
 		properties: {
@@ -49,4 +49,22 @@ test('sidebar interactive controls expose accessible labels', async ({ page }) =
 
 	await expect(page.getByTestId('sidebar-collapse-toggle')).toHaveAttribute('aria-label', /.+/);
 	await expect(page.locator('input[aria-label]').first()).toHaveAttribute('aria-label', /.+/);
+});
+
+test('entries list is named by the visible count indicator when capped', async ({ page }) => {
+	await mockLargeEntries(page);
+	await page.goto('/#/');
+
+	await expect(page.getByTestId('entry-item')).toHaveCount(200, { timeout: 15000 });
+	await expect(page.getByTestId('entries-list')).toHaveAccessibleName(
+		'250 Einträge · 200 angezeigt'
+	);
+});
+
+test('entries list is named by the visible count indicator when uncapped', async ({ page }) => {
+	await mockLargeEntries(page, 3);
+	await page.goto('/#/');
+
+	await expect(page.getByTestId('entry-item')).toHaveCount(3, { timeout: 15000 });
+	await expect(page.getByTestId('entries-list')).toHaveAccessibleName('3 Einträge');
 });

--- a/packages/map-next/src/lib/components/domain/entries/EntriesList.svelte
+++ b/packages/map-next/src/lib/components/domain/entries/EntriesList.svelte
@@ -36,6 +36,7 @@
 	}: Props = $props();
 
 	const SKELETON_ROW_COUNT = 5;
+	const labelId = $props.id();
 
 	// Skeleton rows only make sense where there is a real async load to wait on —
 	// the my-entries fetch. The public list is populated synchronously from the
@@ -58,7 +59,7 @@
 </script>
 
 <Sidebar.Group>
-	<Sidebar.GroupLabel>
+	<Sidebar.GroupLabel id={labelId}>
 		<div class="flex items-center justify-between gap-2">
 			{#if hasCappedEntries}
 				<span data-testid="entries-cap-indicator">
@@ -77,6 +78,7 @@
 			bind:ref={listEl}
 			data-testid="entries-list"
 			aria-busy={isMyEntriesScope && isLoading}
+			aria-labelledby={labelId}
 		>
 			{#if showSkeleton}
 				{#each Array.from({ length: SKELETON_ROW_COUNT }) as _, index (index)}

--- a/packages/map-next/src/lib/components/domain/entries/MyEntriesList.svelte
+++ b/packages/map-next/src/lib/components/domain/entries/MyEntriesList.svelte
@@ -38,6 +38,7 @@
 	}: Props = $props();
 
 	const SKELETON_ROW_COUNT = 5;
+	const labelId = $props.id();
 	const showSkeleton = $derived(isLoading && features.length === 0);
 
 	type FarmNode = {
@@ -138,7 +139,7 @@
 {/snippet}
 
 <Sidebar.Group>
-	<Sidebar.GroupLabel>
+	<Sidebar.GroupLabel id={labelId}>
 		<div class="flex items-center justify-between gap-2">
 			<span>{m.map_sidebar_entries_count({ count: features.length })}</span>
 			{#if isLoading}
@@ -148,7 +149,7 @@
 	</Sidebar.GroupLabel>
 	<Sidebar.GroupContent>
 		{#if showSkeleton}
-			<Sidebar.Menu data-testid="entries-list" aria-busy="true">
+			<Sidebar.Menu data-testid="entries-list" aria-busy="true" aria-labelledby={labelId}>
 				{#each Array.from({ length: SKELETON_ROW_COUNT }) as _, index (index)}
 					<Sidebar.MenuItem data-testid="entry-skeleton">
 						<div class="flex items-start gap-3 px-2 py-3">
@@ -172,7 +173,7 @@
 				{m.map_sidebar_my_entries_empty()}
 			</p>
 		{:else}
-			<Sidebar.Menu data-testid="entries-list" aria-busy={isLoading}>
+			<Sidebar.Menu data-testid="entries-list" aria-busy={isLoading} aria-labelledby={labelId}>
 				{#each nodes as node (node.key)}
 					{#if node.kind === 'main'}
 						{@render entryRow(node.feature, false)}

--- a/specs/map-next-entry-list-a11y/plan.md
+++ b/specs/map-next-entry-list-a11y/plan.md
@@ -92,12 +92,12 @@ under `src/lib/components/ui/` is modified.
         `aria-busy` on the `<ul>` is retained; add e2e coverage in
         `e2e/perf-accessibility-sanity.test.ts`.
 
-- [ ] 8. The list has an accessible name (depends on: none)
-  - [ ] 8.1 In `EntriesList.svelte`, generate a stable id with Svelte 5 `$props.id()`, pass it
+- [x] 8. The list has an accessible name (depends on: none)
+  - [x] 8.1 In `EntriesList.svelte`, generate a stable id with Svelte 5 `$props.id()`, pass it
         to `Sidebar.GroupLabel`, and reference it from `Sidebar.Menu` via `aria-labelledby`.
-  - [ ] 8.2 Do the same in `MyEntriesList.svelte` — note it renders two separate
+  - [x] 8.2 Do the same in `MyEntriesList.svelte` — note it renders two separate
         `Sidebar.Menu` instances (skeleton and populated); both need the `aria-labelledby`.
-  - [ ] 8.3 Verify the `<ul>`'s computed accessible name equals the visible label text in both
+  - [x] 8.3 Verify the `<ul>`'s computed accessible name equals the visible label text in both
         the capped ("250 Einträge · 200 angezeigt") and uncapped variants; add e2e coverage in
         `e2e/perf-accessibility-sanity.test.ts`.
 


### PR DESCRIPTION
Implements feature 8 of `specs/map-next-entry-list-a11y`: the entry-list `<ul>` had no accessible name, because the visible entry count was an unassociated `<div>`.

Each list now generates a stable id with Svelte 5's `$props.id()`, puts it on its `Sidebar.GroupLabel`, and references it from `Sidebar.Menu` via `aria-labelledby` — so the `<ul>`'s computed accessible name is the visible count text, in both the capped ("250 Einträge · 200 angezeigt") and uncapped variants. `MyEntriesList` renders two separate `Sidebar.Menu` instances (skeleton and populated) and both are covered. Everything reaches the primitives through `restProps`, so no file under `src/lib/components/ui/` is touched, per the spec's hard constraint.

Verified with `npm run check` (0 errors), prettier/eslint, and Playwright run serially over the entry-list suites (`perf-accessibility-sanity`, `my-entries-scope`, `bbox-follow`, `depot-interaction`, `detail-profile-polish`) — 15/15 pass, including the two new accessible-name tests.

## Review notes

An independent review pass returned three minor findings, none blocking and none applied here:

1. The two `MyEntriesList` `<ul>`s have no e2e coverage — both new tests hit `/#/` unauthenticated, so they only exercise `EntriesList`. Not an AC violation (AC 8.3 names only the capped/uncapped variants), but feature 1 rewrites exactly that farm-group markup and nothing would catch a dropped `aria-labelledby` there.
2. `aria-labelledby` targets the whole `GroupLabel`, whose subtree also holds the conditional "Lädt…" span, so the my-entries list's name is `"12 Einträge Lädt…"` during a refetch and `"12 Einträge"` after. Pointing at the count `<span>` instead would keep it stable — worth deciding together with feature 9, which turns that same element into a live region.
3. A local `packages/map-next/pw-local.config.ts` (Playwright on port 4176) was used to work around a port-4173 collision with other Conductor workspaces. It is deliberately **not** committed, but it is untracked and not gitignored — delete it or ignore it before any `git add -A`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)