### PR TITLE
fix(map-next): restore the pointer cursor on enabled buttons and links

### DIFF
--- a/packages/map-next/src/lib/components/domain/map/RegionFilters.svelte
+++ b/packages/map-next/src/lib/components/domain/map/RegionFilters.svelte
@@ -34,7 +34,10 @@
 		<Select.Root type="single" value={selectedCountry} onValueChange={onCountrySelect}>
 			<!-- Shell-level control: keep the prominent --control-border and the generous
 			     shell radius (rounded-2xl), not the softer/less-rounded form defaults. -->
-			<Select.Trigger id="country-browse-select" class="w-full rounded-2xl border-control-border">
+			<Select.Trigger
+				id="country-browse-select"
+				class="w-full cursor-pointer rounded-2xl border-control-border"
+			>
 				{selectedCountryLabel}
 			</Select.Trigger>
 			<Select.Content class="z-[var(--z-map-overlay)]">
@@ -56,7 +59,10 @@
 		>
 			<!-- Shell-level control: keep the prominent --control-border and the generous
 			     shell radius (rounded-2xl), not the softer/less-rounded form defaults. -->
-			<Select.Trigger id="region-browse-select" class="w-full rounded-2xl border-control-border">
+			<Select.Trigger
+				id="region-browse-select"
+				class="w-full cursor-pointer rounded-2xl border-control-border"
+			>
 				{selectedStateLabel}
 			</Select.Trigger>
 			<Select.Content class="z-[var(--z-map-overlay)]">

--- a/packages/map-next/src/routes/layout.css
+++ b/packages/map-next/src/routes/layout.css
@@ -157,6 +157,27 @@
 	}
 
 	/*
+	 * Tailwind v4 dropped the preflight `cursor: pointer` reset for buttons, so
+	 * restore it here. The rule is: match the native equivalent — native
+	 * `<button>`/`<a href>` show a pointer, native `<select>`/checkbox/radio show
+	 * an arrow, so the primitives emulating those are excluded by `data-slot`.
+	 * Components that already set a `cursor-*` utility (menu/select/command items,
+	 * the bottom-sheet drag handle, the sidebar rail) need no exclusion: Tailwind's
+	 * utilities layer always beats `@layer base`, regardless of specificity.
+	 */
+	button:not(
+		:disabled,
+		[aria-disabled='true'],
+		[data-slot='select-trigger'],
+		[data-slot='checkbox'],
+		[data-slot='radio-group-item']
+	),
+	[role='button']:not([aria-disabled='true']),
+	a[href] {
+		cursor: pointer;
+	}
+
+	/*
 	 * Shadow DOM support: Apply base styles to the shadow wrapper element
 	 * when running in embedded mode via teikei-loader.js
 	 *

--- a/specs/map-next-entry-list-a11y/plan.md
+++ b/specs/map-next-entry-list-a11y/plan.md
@@ -27,19 +27,19 @@ under `src/lib/components/ui/` is modified.
         e2e suites touching the list still pass; add e2e coverage for the `href` value and for
         ⌘/middle-click opening a new tab without disturbing the current list.
 
-- [ ] 2. Application-wide pointer cursor on buttons and links (depends on: none)
-  - [ ] 2.1 Add the `@layer base` cursor rule from the spec to `src/routes/layout.css`,
+- [x] 2. Application-wide pointer cursor on buttons and links (depends on: none)
+  - [x] 2.1 Add the `@layer base` cursor rule from the spec to `src/routes/layout.css`,
         excluding `:disabled`, `[aria-disabled='true']`, and the `select-trigger` / `checkbox` /
         `radio-group-item` data-slots.
-  - [ ] 2.2 Add `cursor-pointer` to the existing inline `class` on both region-filter
+  - [x] 2.2 Add `cursor-pointer` to the existing inline `class` on both region-filter
         `Select.Trigger`s in `src/lib/components/domain/map/RegionFilters.svelte:37,59`.
-  - [ ] 2.3 Verify pointer appears on: entry rows, `AppButton`/`IconButton`, accordion
+  - [x] 2.3 Verify pointer appears on: entry rows, `AppButton`/`IconButton`, accordion
         triggers, dropdown-menu triggers, and the hand-rolled buttons in `GeocoderField`,
         `MultiSelectCombobox`, `FarmDepotsSection`.
-  - [ ] 2.4 Verify a non-pointer cursor remains on: dropdown-menu / select / command items,
+  - [x] 2.4 Verify a non-pointer cursor remains on: dropdown-menu / select / command items,
         checkboxes, radio items, non-region-filter select triggers, the bottom-sheet drag
         handle (`grab`/`grabbing`), the sidebar rail (resize), and disabled controls.
-  - [ ] 2.5 Confirm `git diff` shows no change under `src/lib/components/ui/`.
+  - [x] 2.5 Confirm `git diff` shows no change under `src/lib/components/ui/`.
 
 - [ ] 3. Hover fill retuned for the cream panel (depends on: none)
   - [ ] 3.1 Add `--base-color-cream-200: oklch(0.88 0.008 170.4)` to `src/lib/design/theme-vars.css`.


### PR DESCRIPTION
Tailwind v4 dropped the preflight `cursor: pointer` reset for buttons and no component re-added it, so every button in map-next — including the sidebar entry rows — showed an arrow and read as inert text. This adds a single `@layer base` rule in `src/routes/layout.css` covering `button`, `[role=button]` and `a[href]`, excluding disabled/`aria-disabled` controls and the primitives that emulate a native `<select>`, checkbox or radio (which show an arrow natively); components that already set a `cursor-*` utility need no exclusion because Tailwind's utilities layer outranks `@layer base`. The two region-filter `Select.Trigger`s opt back in at the call site, since they are shell chrome styled to match the nav buttons. No vendored primitive under `src/lib/components/ui/` is touched.

This implements feature 2 of `specs/map-next-entry-list-a11y` and checks off tasks 2.1–2.5; next up in that plan is task 1.1.

## Verification

- `npm run check` 0 errors, `npm run lint` clean, `npm run test:unit` 107 passed.
- A throwaway Playwright suite (6 tests, deleted before commit) asserted `getComputedStyle().cursor` on the real components: **pointer** on entry rows, `IconButton`, `AppButton` (both `<button>` and `<a href>` forms), accordion triggers, dropdown-menu triggers, region-filter select triggers, and the hand-rolled buttons in `GeocoderField`, `MultiSelectCombobox`, `FarmDepotsSection`; **non-pointer** on select/dropdown-menu/command items, checkboxes, radio items, plain select triggers, the disabled region select (`not-allowed`), and the bottom-sheet drag handle (`grab`).
- Confirmed in the compiled CSS that layers emit `properties → theme → base → components → utilities`, so `cursor-*` utilities really do beat the new base rule.
- Full e2e suite: the only 2 failures reproduce on `preview` without this change (`inline-edit-create.test.ts:502` fails on base; `contact-drawer.test.ts:260` is flaky on base, 1 of 4 runs).
- The sidebar rail is not used anywhere in the app, so its resize cursors could not be verified in-app; its `cursor-*-resize` utilities sit in the winning utilities layer.

## Proposals

Two minor points surfaced in review. Both stem from wording in `spec.md`, which is single-writer, so they are left unchanged here:

1. **`a[href]` has no `aria-disabled` exclusion**, unlike the two button branches, which is asymmetric with the criterion "A disabled or `aria-disabled` control does not show a pointer cursor." It is latent, not live: `ui/button/button.svelte` drops `href` when disabled, so nothing matches today. Suggested spec change — make the third selector `a[href]:not([aria-disabled='true'])`.
2. **Geocoder suggestions now show a pointer while `Command.Item`/`Select.Item` option lists show an arrow.** The spec explicitly lists `forms/GeocoderField.svelte` under "should show pointer", so this PR is conformant, but the two option lists are semantically the same control and will look inconsistent side by side. Worth deciding whether the geocoder suggestions should instead adopt `cursor-default` to match the other option lists.