### PR TITLE
feat(map-next): make public entry rows real links

### DIFF
--- a/packages/map-next/e2e/depot-on-profile.test.ts
+++ b/packages/map-next/e2e/depot-on-profile.test.ts
@@ -489,4 +489,11 @@ test('my-entries groups a cross-owned depot under the foreign farm with an owner
 	const crossDepotRow = page.getByTestId('entry-item').filter({ hasText: 'Cross Depot' });
 	await expect(crossDepotRow).toBeVisible();
 	await expect(crossDepotRow.getByTestId('entry-action-edit-inline')).toBeVisible();
+
+	// The farm group must not reintroduce a non-<li> child of a <ul>.
+	await expect(
+		page.locator(
+			'[data-testid="entries-list"] > :not(li), [data-testid="entries-list"] ul > :not(li)'
+		)
+	).toHaveCount(0);
 });

--- a/packages/map-next/e2e/perf-accessibility-sanity.test.ts
+++ b/packages/map-next/e2e/perf-accessibility-sanity.test.ts
@@ -25,9 +25,19 @@ async function mockLargeEntries(page: Page) {
 		}
 	}));
 
-	await page.route(/\/entries(?:\/)?(?:\?.*)?$/, (route) =>
-		fulfillJson(route, { type: 'FeatureCollection', features })
-	);
+	// Context-scoped so tabs opened by a modified click inherit the mocks too.
+	await page
+		.context()
+		.route(/\/entries(?:\/)?(?:\?.*)?$/, (route) =>
+			fulfillJson(route, { type: 'FeatureCollection', features })
+		);
+	await page.context().route(/\/farms\/farm-\d+$/, (route) => {
+		const id = new URL(route.request().url()).pathname.split('/').pop();
+		return fulfillJson(
+			route,
+			features.find((feature) => feature.properties.id === id)
+		);
+	});
 }
 
 test('sidebar caps rendered rows for large all-entries lists and exposes cap indicator', async ({
@@ -41,6 +51,62 @@ test('sidebar caps rendered rows for large all-entries lists and exposes cap ind
 	await expect(page.getByTestId('entries-cap-indicator')).toHaveText(
 		'250 Einträge · 200 angezeigt'
 	);
+});
+
+test('entry rows are links pointing at the entry detail route', async ({ page }) => {
+	await mockLargeEntries(page);
+	await page.goto('/#/');
+
+	const firstRow = page.getByTestId('entry-row').first();
+	await expect(firstRow).toBeVisible({ timeout: 15000 });
+	await expect(firstRow).toHaveJSProperty('tagName', 'A');
+	await expect(firstRow).toHaveAttribute('href', '#/farms/farm-0');
+});
+
+test('modified clicks on an entry row open a new tab and leave the list untouched', async ({
+	page
+}) => {
+	await mockLargeEntries(page);
+	await page.goto('/#/');
+
+	const firstRow = page.getByTestId('entry-row').first();
+	await expect(firstRow).toBeVisible({ timeout: 15000 });
+
+	for (const openInNewTab of [
+		() => firstRow.click({ modifiers: ['ControlOrMeta'] }),
+		() => firstRow.click({ button: 'middle' })
+	]) {
+		const popupPromise = page.context().waitForEvent('page');
+		await openInNewTab();
+		const popup = await popupPromise;
+		await expect.poll(() => popup.url(), { timeout: 15000 }).toContain('#/farms/farm-0');
+		await popup.close();
+
+		expect(page.url()).not.toContain('farms/farm-0');
+		await expect(page.getByTestId('entry-item')).toHaveCount(200);
+	}
+});
+
+// Rows sit under `data-sveltekit-preload-data="hover"` on <body>, and hovering the
+// list is the normal way to find a marker — so preloading must stay off the hover path.
+test('hovering entry rows preloads no detail data', async ({ page }) => {
+	await mockLargeEntries(page);
+
+	const detailRequests: string[] = [];
+	page.on('request', (request) => {
+		if (/\/farms\/farm-\d+$/.test(new URL(request.url()).pathname)) {
+			detailRequests.push(request.url());
+		}
+	});
+
+	await page.goto('/#/');
+	await expect(page.getByTestId('entry-row').first()).toBeVisible({ timeout: 15000 });
+
+	for (let index = 0; index < 5; index++) {
+		await page.getByTestId('entry-row').nth(index).hover();
+	}
+	await page.waitForTimeout(1500);
+	expect(detailRequests).toEqual([]);
 });
 
 test('sidebar interactive controls expose accessible labels', async ({ page }) => {

--- a/packages/map-next/src/lib/components/domain/entries/EntriesList.svelte
+++ b/packages/map-next/src/lib/components/domain/entries/EntriesList.svelte
@@ -4,6 +4,7 @@
 	import { AppButton } from '$lib/components/actions';
 	import type { EntryFeature } from '$lib/types/entries';
 	import { cn } from '$lib/utils/tailwind';
+	import { routeBuilders } from '$lib/utils/routes';
 	import { entryHoverKey, hoveredEntry } from '$lib/stores/hovered-entry.svelte';
 	import * as m from '$lib/paraglide/messages.js';
 	import EntryCard from './EntryCard.svelte';
@@ -55,6 +56,16 @@
 		const target = listEl.querySelector(`[data-entry-key="${CSS.escape(key)}"]`);
 		target?.scrollIntoView({ block: 'nearest' });
 	});
+
+	// Rows are real links, so only a plain primary click is handled in-app —
+	// modified and non-primary clicks stay with the browser (new tab, etc.).
+	function handleRowClick(event: MouseEvent, feature: EntryFeature) {
+		if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+			return;
+		}
+		event.preventDefault();
+		onEntryClick(feature);
+	}
 </script>
 
 <Sidebar.Group>
@@ -100,11 +111,19 @@
 							class={cn('h-auto py-3', isMyEntriesScope && 'pr-12 lg:pr-34')}
 							data-testid="entry-row"
 							data-entry-key={key}
-							onclick={() => onEntryClick(feature)}
+							onclick={(event: MouseEvent) => handleRowClick(event, feature)}
 							onmouseenter={() => hoveredEntry.setHover(props, 'list')}
 							onmouseleave={() => hoveredEntry.clear(props)}
 						>
-							<EntryCard entry={props} highlighted={hoveredEntry.key === key} />
+							{#snippet child({ props: rowProps })}
+								<a
+									href={routeBuilders.entryDetail(props.type, props.id)}
+									data-sveltekit-preload-data="tap"
+									{...rowProps}
+								>
+									<EntryCard entry={props} highlighted={hoveredEntry.key === key} />
+								</a>
+							{/snippet}
 						</Sidebar.MenuButton>
 						{#if isMyEntriesScope}
 							<EntryRowActions

--- a/packages/map-next/src/lib/components/domain/entries/MyEntriesList.svelte
+++ b/packages/map-next/src/lib/components/domain/entries/MyEntriesList.svelte
@@ -179,14 +179,13 @@
 					{:else if node.kind === 'orphan-depot'}
 						{@render entryRow(node.depot, false)}
 					{:else}
-						<div
+						{@const ownFarm = node.isOwnFarm ? node.farm : undefined}
+						<li
 							class="flex flex-col"
 							data-testid="my-entries-farm-group"
 							data-own-farm={node.isOwnFarm}
 						>
-							{#if node.isOwnFarm && node.farm}
-								{@render entryRow(node.farm, false)}
-							{:else}
+							{#if !ownFarm}
 								<div
 									class="flex flex-col gap-0.5 px-2 pt-3 pb-1"
 									data-testid="my-entries-foreign-farm-header"
@@ -197,10 +196,15 @@
 									</span>
 								</div>
 							{/if}
-							{#each node.depots as depot (depot.properties.id)}
-								{@render entryRow(depot, true)}
-							{/each}
-						</div>
+							<Sidebar.Menu class="gap-0">
+								{#if ownFarm}
+									{@render entryRow(ownFarm, false)}
+								{/if}
+								{#each node.depots as depot (depot.properties.id)}
+									{@render entryRow(depot, true)}
+								{/each}
+							</Sidebar.Menu>
+						</li>
 					{/if}
 				{/each}
 			</Sidebar.Menu>

--- a/packages/map-next/src/lib/utils/routes.spec.ts
+++ b/packages/map-next/src/lib/utils/routes.spec.ts
@@ -25,6 +25,12 @@ describe('routes utils', () => {
 		expect(routeBuilders.discovery.position(47.37, 8.54)).toBe('#/position/47.37,8.54');
 	});
 
+	it('builds entry detail routes per entry type', () => {
+		expect(routeBuilders.entryDetail('Farm', '42')).toBe('#/farms/42');
+		expect(routeBuilders.entryDetail('Initiative', 'abc')).toBe('#/initiatives/abc');
+		expect(routeBuilders.entryDetail('Depot', 'depot 7')).toBe('#/depots/depot%207');
+	});
+
 	it('builds redirect route for sign-in with encoded redirect query', () => {
 		expect(routeBuilders.auth.signInWithRedirect('#/users/editaccount')).toBe(
 			'#/users/sign-in?redirect=%23%2Fusers%2Feditaccount'

--- a/packages/map-next/src/routes/MapSidebar.svelte.spec.ts
+++ b/packages/map-next/src/routes/MapSidebar.svelte.spec.ts
@@ -217,7 +217,7 @@ describe('MapSidebar', () => {
 		const farmTextNode = Array.from(document.querySelectorAll('*')).find(
 			(node) => node.textContent?.trim() === 'Farm Two'
 		);
-		const farmRow = farmTextNode?.closest('button');
+		const farmRow = farmTextNode?.closest('[data-testid="entry-row"]');
 		if (!(farmRow instanceof HTMLElement)) {
 			throw new Error('Expected a clickable sidebar row for farm entry');
 		}

--- a/specs/map-next-entry-list-a11y/plan.md
+++ b/specs/map-next-entry-list-a11y/plan.md
@@ -7,23 +7,23 @@ Status legend: [ ] todo · [~] in progress · [x] done
 All paths are relative to `packages/map-next/`. Hard constraint across every feature: no file
 under `src/lib/components/ui/` is modified.
 
-- [ ] 1. Entry rows as links (depends on: none)
-  - [ ] 1.1 Confirm `routeBuilders.entryDetail(entryType, id)` in `src/lib/utils/routes.ts`
+- [x] 1. Entry rows as links (depends on: none)
+  - [x] 1.1 Confirm `routeBuilders.entryDetail(entryType, id)` in `src/lib/utils/routes.ts`
         returns the correct URL for all three row types (Farm → `#/farms/:id`, Initiative →
         `#/initiatives/:id`, Depot → `#/depots/:id`); add unit coverage if absent.
-  - [ ] 1.2 In `src/lib/components/domain/entries/EntriesList.svelte`, render the row through
+  - [x] 1.2 In `src/lib/components/domain/entries/EntriesList.svelte`, render the row through
         `Sidebar.MenuButton`'s `child` snippet as `<a href={routeBuilders.entryDetail(...)}>`,
         spreading the snippet's merged props so classes, `data-testid="entry-row"` and
         `data-entry-key` are unchanged.
-  - [ ] 1.3 Guard the row click handler so it only `preventDefault`s plain primary clicks —
+  - [x] 1.3 Guard the row click handler so it only `preventDefault`s plain primary clicks —
         let ⌘/Ctrl/Shift/Alt-click, middle-click and context-menu fall through to the browser.
         Plain clicks keep calling `handleEntryClick` (map pan + `goto`) exactly as today.
-  - [ ] 1.4 In `src/lib/components/domain/entries/MyEntriesList.svelte`, restructure the farm
+  - [x] 1.4 In `src/lib/components/domain/entries/MyEntriesList.svelte`, restructure the farm
         group so `data-testid="my-entries-farm-group"` no longer renders a `<div>` as a direct
         child of the `<ul>`; keep the existing test id and `data-own-farm` attribute on
         whatever element replaces it.
-  - [ ] 1.5 Confirm my-entries rows are still `<button>` with no `href` (they only pan the map).
-  - [ ] 1.6 Verify row visuals are unchanged (no underline, no link color) and the existing
+  - [x] 1.5 Confirm my-entries rows are still `<button>` with no `href` (they only pan the map).
+  - [x] 1.6 Verify row visuals are unchanged (no underline, no link color) and the existing
         e2e suites touching the list still pass; add e2e coverage for the `href` value and for
         ⌘/middle-click opening a new tab without disturbing the current list.
 


### PR DESCRIPTION
Implements feature 1 of `specs/map-next-entry-list-a11y`: rows in the public entry list navigate to deep-linkable hash URLs but were rendered as `<button>`, so they now render through `Sidebar.MenuButton`'s `child` snippet as `<a href={routeBuilders.entryDetail(type, id)}>`, with the click handler only calling `preventDefault` on plain primary clicks so ⌘/Ctrl- and middle-click open a new tab. Rows carry `data-sveltekit-preload-data="tap"` because the app sets `hover` globally on `<body>` and hovering the list is the normal way to locate a map marker — the default fired one detail request per hovered row (measured: 5 hovers → 5 requests) across a list of up to 200. My-entries rows stay `<button>` since they only pan the map, and its farm group moves from a `<div>` child of `<ul>` to an `<li>` wrapping a nested `Sidebar.Menu`, so the list is well-formed and screen readers report the correct item count. No file under `src/lib/components/ui/` is touched — everything goes through the vendored primitives' supported seams.

Verified: `npm run check` 0 errors · `vitest run` 108/108 · 26/26 e2e serially across `perf-accessibility-sanity`, `my-entries-scope`, `detail-profile-polish`, `depot-on-profile`, `legacy-routes`, `bbox-follow`, `region-browsing`, including new coverage for the `href` value, modified-click behaviour, hover-preload absence, and list markup validity.

## Proposals

Two items outside this task's scope, for a separate decision:

- **`packages/map-next/playwright.config.ts` `webServer.timeout`** — the default 60s is shorter than `npm run build && npm run preview` typically takes. When it trips, Playwright kills the server but the port can stay occupied, producing `ERR_CONNECTION_REFUSED` cascades that read as test failures. Suggested: add `timeout: 300000`.
- **Port 4173 is not per-workspace** — another Conductor workspace serving its own build on 4173 caused Playwright's default `reuseExistingServer` to silently run this suite against *that* build. Worth making the port env-configurable, or documenting the `lsof -ti :4173` check.

Also worth knowing: the full e2e suite is flaky under parallel workers — 12 failures at baseline vs 10 with this change, non-overlapping sets, all green with `--workers=1`. Not caused by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)