### PR TITLE
docs(specs): migrate PR-description proposals into proposals.md files

### DIFF
--- a/specs/map-next-design-consistency/proposals.md
+++ b/specs/map-next-design-consistency/proposals.md
@@ -1,0 +1,56 @@
+# Proposals
+
+Triage inbox for spec/plan change proposals. `implement` appends, the human triages by
+flipping `[open]` to `[applied]` or `[rejected]` (or deleting the entry).
+
+_Entries below were migrated from PR descriptions, which is where proposals were recorded
+before `proposals.md` existed. The **Source** line points at the originating PR._
+
+## [open] 4 — Wizard × Feature 4 interaction: the interim heading fix is throwaway
+
+- **Source:** PR #867
+- **Gap:** The still-live creation wizard shares the section components that now carry
+  Feature 4's canonical headings, so the two heading systems stack. The spec does not
+  acknowledge this overlap between Feature 4 and Feature 9.
+- **Handled:** Interim fix — the wizard step title renders only on the identity step.
+- **Proposed change:** Add a note to `spec.md` under Feature 9: "Until the wizard is
+  removed, its step-title heading duplicates the canonical section headings introduced by
+  Feature 4; the interim fix is throwaway."
+
+## [open] 4 — Badges heading mislabels certification-only entries
+
+- **Source:** PR #867 (review finding, skipped by decision)
+- **Gap:** Feature 4's "one term per section" rule chose "Verbände und Netzwerke", which
+  mislabels entries whose badges are all certifications.
+- **Handled:** Left as-is — the PR is conformant with the spec as written; flagged rather
+  than silently diverging.
+- **Proposed change:** If revisited, add the criterion: "An entry whose badges are all
+  certifications is headed appropriately (e.g. 'Zertifizierungen' as the sole heading)."
+
+## [open] 11.3 — Runtime verification of shadow-DOM + standalone portal modes is unrunnable here
+
+- **Source:** PR #869
+- **Gap:** Task 11.3 requires runtime verification in both embedded shadow-DOM and
+  standalone modes, but that workspace could not run the app (`@sveltejs/kit`/`vite`/
+  `svelte-kit` absent, Node v26 breaks the svelte toolchain).
+- **Handled:** Task 11.3 left unchecked and Feature 11 left `[~]` in progress rather than
+  claiming unverified completion. Code reviewed clean at high effort: the `to`-prop
+  precedence preserves any caller-supplied target and `to={undefined}` is equivalent to
+  omitting it, so standalone `document.body` portaling is unchanged.
+- **Proposed change:** Verify in a full environment with `npm run dev` plus the embed demo —
+  confirm select/dropdown content lands in `#teikei-portal-container` in the shadow root and
+  that the "Solawi seit (Jahr)" select opens anchored with internal scroll, then re-check
+  standalone mode. Then close 11.3 and Feature 11.
+
+## [applied] 12.6 — Map-focus offset hardcodes the 500px sidebar width
+
+- **Source:** PR #871 (approved in-session, folded into Feature 12)
+- **Gap:** `currentFocusOffset()` in `routes/Map.svelte` hardcodes the 500px
+  `MAP_SIDEBAR_WIDTH_PX`, so with Feature 10's new 680px editor a point centered while the
+  editor is open sits left-of-center in the reduced pane (the marker stays visible — low
+  severity). No plan task covered this.
+- **Handled:** Not fixed inside PR #871; instead folded into Feature 12's polish sweep as a
+  new task rather than widening that PR's scope.
+- **Proposed change:** Add task 12.6 to `plan.md` — make the offset mode-aware via
+  `getSidebarFocusOffset`'s existing `sidebarWidth` param. _(Applied: task 12.6 exists in
+  `plan.md` and is complete.)_

--- a/specs/map-next-entry-list-a11y/proposals.md
+++ b/specs/map-next-entry-list-a11y/proposals.md
@@ -1,0 +1,78 @@
+# Proposals
+
+Triage inbox for spec/plan change proposals. `implement` appends, the human triages by
+flipping `[open]` to `[applied]` or `[rejected]` (or deleting the entry).
+
+_Entries below were migrated from PR descriptions, which is where proposals were recorded
+before `proposals.md` existed. The **Source** line points at the originating PR._
+
+## [open] 3 — Feature 3's contrast criteria and per-theme figures are miscalculated
+
+- **Source:** PR #895
+- **Gap:** The criterion "`--sidebar-accent` measures between 1.15:1 and 1.30:1 against
+  `--sidebar` in every theme" is unsatisfiable by the tokens the spec itself prescribes:
+  they measure **1.64:1** (teikei) and **1.54:1** (client-demo), and client-demo's value is
+  pinned by an existing token, so the 1.30 ceiling is unreachable without changing mist-200.
+  The stated per-theme figures are also wrong: old olive-100 on cream is 1.08:1, not
+  1.035:1, and the foregrounds are olive-900 on cream-200 = 9.3:1 and ink-900 on mist-200 =
+  12.2:1 (the spec says ≈12.2 / ≈14.0).
+- **Handled:** The tokens were implemented as prescribed and all ratios recomputed from the
+  oklch values (oklch → linear sRGB → WCAG luminance, conversion sanity-checked against
+  known hexes). Feature 3's plan line was left `[~]` pending this spec fix rather than
+  closed against criteria it cannot meet.
+- **Proposed change:** Replace those bullets in `spec.md` with:
+
+  > - `teikei`'s `--sidebar-accent` becomes `--base-color-cream-200`: measured **1.64:1**
+  >   against `--sidebar`.
+  > - `client-demo`'s `--sidebar-accent` becomes the existing `--base-color-mist-200`:
+  >   measured **1.54:1** against `--sidebar` (`--base-color-mist-50`).
+  > - `--sidebar-accent` measures at least 1.15:1 against `--sidebar` in every theme.
+  > - `--sidebar-accent-foreground` is unchanged and stays ≥4.5:1 on the new fill
+  >   (olive-900 on cream-200 = 9.3:1; ink-900 on mist-200 = 12.2:1).
+
+## [open] 2 — The `a[href]` cursor selector has no `aria-disabled` exclusion
+
+- **Source:** PR #899
+- **Gap:** The prescribed `a[href]` selector lacks the `aria-disabled` exclusion that both
+  button branches carry, which is asymmetric with the criterion "A disabled or
+  `aria-disabled` control does not show a pointer cursor."
+- **Handled:** Implemented as the spec writes it — the gap is latent, not live:
+  `ui/button/button.svelte` drops `href` when disabled, so nothing matches today.
+- **Proposed change:** Make the third selector `a[href]:not([aria-disabled='true'])` in
+  `spec.md` (and in `src/routes/layout.css`).
+
+## [open] 2 — Geocoder suggestions show a pointer while other option lists show an arrow
+
+- **Source:** PR #899
+- **Gap:** `forms/GeocoderField.svelte` is explicitly listed under "should show pointer",
+  but `Command.Item`/`Select.Item` option lists keep the arrow. The two are semantically the
+  same control and will look inconsistent side by side.
+- **Handled:** Implemented per the spec, so the PR is conformant; flagged rather than
+  silently diverging.
+- **Proposed change:** Decide whether the geocoder suggestions should instead adopt
+  `cursor-default` to match the other option lists, and update the Feature 2 lists in
+  `spec.md` accordingly.
+
+## [open] 1 — Playwright `webServer.timeout` default is too short for build + preview
+
+- **Source:** PR #900 (outside the task's scope)
+- **Gap:** `packages/map-next/playwright.config.ts` relies on the default 60s
+  `webServer.timeout`, which is shorter than `npm run build && npm run preview` typically
+  takes. When it trips, Playwright kills the server but the port can stay occupied,
+  producing `ERR_CONNECTION_REFUSED` cascades that read as test failures.
+- **Handled:** Not changed in the PR — out of scope for the task.
+- **Proposed change:** Add `timeout: 300000` to `webServer` in
+  `packages/map-next/playwright.config.ts`.
+
+## [open] 1 — Playwright port 4173 is not per-workspace
+
+- **Source:** PR #900 (outside the task's scope)
+- **Gap:** Another Conductor workspace serving its own build on port 4173 caused
+  Playwright's default `reuseExistingServer` to silently run the suite against _that_ build.
+- **Handled:** Not changed in the PR — out of scope for the task. Worked around manually.
+- **Proposed change:** Make the preview port env-configurable, or document the
+  `lsof -ti :4173` check in the e2e instructions.
+
+  Also worth knowing (not a proposal): the full e2e suite is flaky under parallel workers —
+  12 failures at baseline vs 10 with PR #900's change, non-overlapping sets, all green with
+  `--workers=1`.

--- a/specs/map-next-parity-ux/proposals.md
+++ b/specs/map-next-parity-ux/proposals.md
@@ -1,0 +1,53 @@
+# Proposals
+
+Triage inbox for spec/plan change proposals. `implement` appends, the human triages by
+flipping `[open]` to `[applied]` or `[rejected]` (or deleting the entry).
+
+_Entries below were migrated from PR descriptions, which is where proposals were recorded
+before `proposals.md` existed. The **Source** line points at the originating PR._
+
+## [open] 7.3 — The `search-widget` stub should stay, not be removed
+
+- **Source:** PR #840
+- **Gap:** Feature 7 in `spec.md` says _"Remove the placeholder `search-widget`
+  (console-log stub) from the widgets build until a real use case exists."_ That turned out
+  to be wrong — the stub should stay.
+- **Handled:** The removal was reverted; `npm run build:widgets` confirms the search-widget
+  still builds as before. Task 7.3 was scoped down to footer/attribution-link verification
+  only, and feature 7 was left `[~]` pending this spec fix.
+- **Proposed change:** Drop that sentence from the Feature 7 description in `spec.md`
+  (currently `spec.md:162`), and correspondingly drop the "and remove the `search-widget`
+  stub from the widgets build (`src/widgets/search-widget`, build config)" clause from
+  `plan.md` task 7.3.
+
+## [open] 1.3 — Task 1.3 references a `validations.json` that map-next does not have
+
+- **Source:** PR #844
+- **Gap:** `plan.md` task 1.3 mentions a `validations.json` file, but per `spec.md`'s
+  Technical Solution map-next has no separate `validations.json` — that file belongs only to
+  the legacy `packages/map` app.
+- **Handled:** Validation messages were resolved through the paraglide `messages/*.json`
+  files instead, which is what the PR does.
+- **Proposed change:** Drop the `validations.json` mention from `plan.md` task 1.3.
+  (Task 3.1 carries the same stale reference.)
+
+## [open] 2 — F2's open API-behavior question is now answered: farm deletion detaches depots
+
+- **Source:** PR #847
+- **Gap:** `spec.md`'s Additional Notes (F2/F8) leaves open whether deleting a farm deletes
+  or detaches its connected depots, and asks for the actual API behavior to be verified.
+- **Handled:** Verified against the new `packages/api` FK constraints: deleting a farm
+  cascades on the `farms_depots` join table only, so **all** connected depots are detached,
+  never deleted, regardless of ownership. The "never delete foreign-owned depots" rule holds
+  by construction and no API change was needed. Editor/dialog copy states that depots are
+  _detached_. Covered by a new e2e suite (consequence copy, farm/initiative removal,
+  foreign-depot survival, cancel-is-a-no-op).
+- **Proposed change:** Add to `spec.md` → Additional Notes:
+
+  > **Resolved (F2):** Deleting a farm removes only the `farms_depots` join rows via
+  > `ON DELETE CASCADE` (migration `20260701120000_add_missing_foreign_keys`), so every
+  > connected depot is **detached, never deleted** — regardless of ownership. Depot records
+  > survive as standalone entries. The "never delete foreign-owned depots" rule is satisfied
+  > by construction; no API change was required. Delete authorization is already enforced on
+  > `remove` by the authorization hook. Editor/dialog copy therefore states that depots are
+  > _detached_ (disconnected), not removed.


### PR DESCRIPTION
Earlier versions of the trails workflow recorded spec/plan change proposals only in PR descriptions; the current version keeps them in a committed `specs/<slug>/proposals.md` inbox. This migrates the 10 proposals found across the PR history (#840, #844, #847, #867, #869, #871, #895, #899, #900) into three such files, in the skill's Gap/Handled/Proposed-change entry format with a `Source` line pointing at the originating PR. Each status was verified against the current `spec.md` and `plan.md` rather than assumed: all entries are still `[open]` except task 12.6 from #871, which was approved in-session and is present and complete in the design-consistency plan. Docs only — no code changes.

PR #901 is deliberately left out: it is still open and its spec slug (`localized-api-errors`) does not exist on this branch, so a lone `proposals.md` there would sit next to no spec and risk an add/add conflict; its proposals stay live in that PR's body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)