### PR TITLE
chore(map-next): deslop comments and unify the farm/initiative profiles

### DIFF
--- a/packages/map-next/scripts/build-embed.js
+++ b/packages/map-next/scripts/build-embed.js
@@ -1,14 +1,8 @@
 #!/usr/bin/env node
 /**
- * Post-build script for the embed bundle.
- *
- * This script:
- * 1. Copies the bundle JS and CSS to stable filenames (main.js, main.css)
- * 2. Replaces the generated __sveltekit_XXXXXX variable name with a stable one (__sveltekit_teikei)
- * 3. Copies the embed-demo.html template to build/index.html
- *
- * This ensures the embedded app can be loaded with stable script URLs and
- * the initialization code in the host page doesn't need to change on each build.
+ * Post-build step for the embed bundle: rewrites the hashed asset names and the
+ * generated `__sveltekit_XXXXXX` global to stable ones, so a host page can point
+ * at fixed script URLs and keep its init code unchanged across builds.
  */
 
 import { readFileSync, writeFileSync, readdirSync, copyFileSync } from 'fs';
@@ -36,7 +30,6 @@ function findFile(dir, pattern) {
 function main() {
 	console.log('Building embed bundle...');
 
-	// JS
 	const bundleFile = findFile(appDir, /^bundle\.[^.]+\.js$/);
 	if (!bundleFile) {
 		console.error('Could not find bundle JS file');
@@ -47,7 +40,6 @@ function main() {
 	const bundlePath = join(appDir, bundleFile);
 	let bundleContent = readFileSync(bundlePath, 'utf-8');
 
-	// stable __sveltekit_XXXXX variable name
 	const sveltekitVarPattern = /__sveltekit_[a-z0-9]+/g;
 	const matches = bundleContent.match(sveltekitVarPattern);
 
@@ -63,7 +55,6 @@ function main() {
 	writeFileSync(mainJsPath, bundleContent);
 	console.log(`Created ${mainJsPath}`);
 
-	// CSS
 	const cssFile = findFile(assetsDir, /\.css$/);
 	if (cssFile) {
 		const cssPath = join(assetsDir, cssFile);
@@ -74,7 +65,6 @@ function main() {
 		console.warn('No CSS file found');
 	}
 
-	// index.html
 	const embedTemplatePath = join(SRC_DIR, 'lib', 'preview', 'embed-demo.html');
 	let embedContent = readFileSync(embedTemplatePath, 'utf-8');
 	embedContent = embedContent.replace(sveltekitVarPattern, STABLE_SVELTEKIT_VAR);

--- a/packages/map-next/scripts/build-widgets.js
+++ b/packages/map-next/scripts/build-widgets.js
@@ -1,11 +1,7 @@
 #!/usr/bin/env node
 /**
- * Build script for widgets.
- *
- * This script:
- * 1. Discovers all widget entry points in src/lib/widgets/
- * 2. Builds each widget separately to ensure proper CSS file naming
- * 3. Copies the widget demo HTML to the build directory
+ * Builds each widget in a separate Vite pass — a single multi-entry build would
+ * emit one shared CSS file, so per-widget CSS naming needs per-widget builds.
  */
 
 import { execSync } from 'child_process';
@@ -18,11 +14,7 @@ const ROOT_DIR = join(__dirname, '..');
 const WIDGETS_BUILD_DIR = join(ROOT_DIR, 'build', 'widgets');
 const WIDGETS_SRC_DIR = join(ROOT_DIR, 'src', 'widgets');
 
-/**
- * Discover all widget entry points:
- * - *.ts files directly in src/widgets/
- * - index.ts files in subdirectories of src/widgets/
- */
+// Entry points are `*.ts` directly in src/widgets/, or `index.ts` one level down.
 function discoverWidgets() {
 	const entries = readdirSync(WIDGETS_SRC_DIR);
 	const widgets = [];
@@ -32,7 +24,6 @@ function discoverWidgets() {
 		const stat = statSync(entryPath);
 
 		if (stat.isDirectory()) {
-			// Check for index.ts in subdirectory
 			const indexPath = join(entryPath, 'index.ts');
 			if (existsSync(indexPath)) {
 				widgets.push({
@@ -41,7 +32,6 @@ function discoverWidgets() {
 				});
 			}
 		} else if (entry.endsWith('.ts') && !entry.endsWith('.d.ts')) {
-			// Direct .ts file in widgets directory
 			widgets.push({
 				name: basename(entry, '.ts'),
 				path: entryPath
@@ -52,18 +42,14 @@ function discoverWidgets() {
 	return widgets;
 }
 
-/**
- * Build a single widget using Vite
- */
 function buildWidget(widget, isFirst) {
 	console.log(`\nBuilding widget: ${widget.name}`);
 
-	// Set environment variable for the widget entry point
 	const env = {
 		...process.env,
 		WIDGET_ENTRY: widget.path,
 		WIDGET_NAME: widget.name,
-		// Only empty the output dir on first build
+		// Only the first build may empty the shared output dir.
 		WIDGET_EMPTY_OUTDIR: isFirst ? 'true' : 'false'
 	};
 
@@ -73,7 +59,7 @@ function buildWidget(widget, isFirst) {
 		env
 	});
 
-	// Rename the CSS file from map.css to widget-name.css
+	// vite.widget.config.ts always emits `map.css`, whatever the entry is named.
 	const mapCssPath = join(WIDGETS_BUILD_DIR, 'map.css');
 	const widgetCssPath = join(WIDGETS_BUILD_DIR, `${widget.name}.css`);
 
@@ -83,9 +69,6 @@ function buildWidget(widget, isFirst) {
 	}
 }
 
-/**
- * Copy demo HTML page to build directory
- */
 function copyDemoPage() {
 	const demoSrc = join(ROOT_DIR, 'src', 'lib', 'preview', 'widgets-demo.html');
 	const demoDest = join(WIDGETS_BUILD_DIR, 'index.html');
@@ -101,12 +84,10 @@ function copyDemoPage() {
 function main() {
 	console.log('Building widgets...\n');
 
-	// Ensure build directory exists
 	if (!existsSync(WIDGETS_BUILD_DIR)) {
 		mkdirSync(WIDGETS_BUILD_DIR, { recursive: true });
 	}
 
-	// Discover widgets
 	const widgets = discoverWidgets();
 
 	if (widgets.length === 0) {
@@ -116,15 +97,13 @@ function main() {
 
 	console.log(`Found ${widgets.length} widget(s): ${widgets.map((w) => w.name).join(', ')}`);
 
-	// Build each widget
 	widgets.forEach((widget, index) => {
 		buildWidget(widget, index === 0);
 	});
 
-	// Copy demo page
 	copyDemoPage();
 
-	console.log('\n✨ Widget build complete!');
+	console.log('\nWidget build complete!');
 }
 
 main();

--- a/packages/map-next/src/app.d.ts
+++ b/packages/map-next/src/app.d.ts
@@ -12,9 +12,6 @@ import type { CurrentUser } from '$lib/types/user';
 
 declare global {
 	namespace App {
-		// interface Error {}
-		// interface Locals {}
-
 		/**
 		 * Union of every shape a route `load` can contribute to `page.data`.
 		 * All keys are optional because each is produced by only some routes;
@@ -44,9 +41,6 @@ declare global {
 			/** Password reset route. */
 			resetToken?: string;
 		}
-
-		// interface PageState {}
-		// interface Platform {}
 	}
 }
 

--- a/packages/map-next/src/hooks.ts
+++ b/packages/map-next/src/hooks.ts
@@ -1,2 +1,2 @@
-// reroute hook removed for hash-based routing compatibility
-// With hash routing, the pathname is always '/' and routes are client-side only
+// No reroute hook: with hash routing the pathname is always '/' and routes are
+// resolved client-side only.

--- a/packages/map-next/src/lib/api/auth.ts
+++ b/packages/map-next/src/lib/api/auth.ts
@@ -96,7 +96,6 @@ export async function signIn(params: SignInParams): Promise<SignInResponse> {
 		errorMessage: 'Sign in failed'
 	});
 
-	// Store access token for future requests
 	if (data.accessToken) {
 		setAccessToken(data.accessToken);
 	}

--- a/packages/map-next/src/lib/components/domain/entries/EntryProfile.svelte
+++ b/packages/map-next/src/lib/components/domain/entries/EntryProfile.svelte
@@ -1,0 +1,321 @@
+<script lang="ts" module>
+	import type { Snippet } from 'svelte';
+	import type { SuperForm } from 'sveltekit-superforms';
+	import type { MainEntryFeature, MainEntryProperties, MainEntryType } from '$lib/types/entries';
+	import type { MainEntryFormData } from '$lib/utils/editor-schema';
+	import type { EditorSectionErrorGroup } from '$lib/utils/editor-form';
+
+	/**
+	 * Handed to the section snippets. `properties` is the union type, so each
+	 * profile narrows it on `type` before passing it to its own domain sections.
+	 */
+	export interface EntryProfileSectionContext {
+		form: SuperForm<MainEntryFormData>;
+		properties?: MainEntryProperties;
+	}
+
+	export interface EntryProfileProps {
+		entryType: MainEntryType;
+		/** The feature; undefined only when creating a new entry. */
+		entry?: MainEntryFeature;
+		mode: 'read' | 'edit';
+		/** Whether the signed-in user owns this entry (Edit action, contact CTA). */
+		canEdit?: boolean;
+		onClose: () => void;
+		onEdit?: () => void;
+		onCancel?: () => void | Promise<void>;
+		onSaved?: (entry: MainEntryFeature) => void | Promise<void>;
+		/** Save-bar error sections beyond the shared identity + description ones. */
+		extraErrorSections?: EditorSectionErrorGroup[];
+		/** Extra read-mode header lines, rendered under the address and website. */
+		headerMeta?: Snippet;
+		editSections: Snippet<[EntryProfileSectionContext]>;
+		readSections: Snippet<[EntryProfileSectionContext]>;
+	}
+</script>
+
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import XIcon from '@lucide/svelte/icons/x';
+	import LinkIcon from '@lucide/svelte/icons/link';
+	import ExternalLinkIcon from '@lucide/svelte/icons/external-link';
+	import { defaults, superForm } from 'sveltekit-superforms';
+	import { zod4, zod4Client } from 'sveltekit-superforms/adapters';
+	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
+	import { SidebarScrollArea } from '$lib/components/layout';
+	import { AppButton, IconButton } from '$lib/components/actions';
+	import { Paragraph } from '$lib/components/typography';
+	import { EditorAccountInfo, EditorSaveBar } from '$lib/components/forms';
+	import IdentitySection from './sections/IdentitySection.svelte';
+	import DescriptionSection from './sections/DescriptionSection.svelte';
+	import { formatEntryAddress } from '$lib/utils/entry-format';
+	import { safeHttpUrl } from '$lib/utils/url';
+	import { copyProfileLink } from '$lib/utils/share';
+	import { routeBuilders } from '$lib/utils/routes';
+	import * as m from '$lib/paraglide/messages.js';
+	import { resolveApiErrorMessage } from '$lib/utils/api-error';
+	import { getPlaceIcon } from '$lib/utils/marker-icons';
+	import {
+		createFarm,
+		updateFarm,
+		createInitiative,
+		updateInitiative
+	} from '$lib/api/entry-mutations';
+	import { createEditorGuard } from '$lib/utils/editor-guard.svelte';
+	import { hasTaintedField, sectionsWithErrors, IDENTITY_FIELD_KEYS } from '$lib/utils/editor-form';
+	import { toastSuccess, toastError } from '$lib/utils/toast';
+	import {
+		mainEntryFormFromFeature,
+		mainEntryFormSchema,
+		mapFarmPayload,
+		mapInitiativePayload
+	} from '$lib/utils/editor-schema';
+
+	let {
+		entryType,
+		entry,
+		mode,
+		canEdit = false,
+		onClose,
+		onEdit,
+		onCancel,
+		onSaved,
+		extraErrorSections = [],
+		headerMeta,
+		editSections,
+		readSections
+	}: EntryProfileProps = $props();
+
+	// Remounted (via `{#key}` in the parent) whenever the entry or mode changes,
+	// so form state is initialised directly from props.
+	// svelte-ignore state_referenced_locally
+	const form = superForm(defaults(mainEntryFormFromFeature(entry), zod4(mainEntryFormSchema)), {
+		validators: zod4Client(mainEntryFormSchema),
+		SPA: true,
+		dataType: 'json'
+	});
+	const { errors, tainted, validateForm } = form;
+
+	let isSaving = $state(false);
+
+	// Everything that differs between the two entry types. Layout does not: both
+	// use the same header/footer padding and the same edit-section dividers.
+	const config = $derived(
+		entryType === 'Farm'
+			? {
+					createTitle: m.editor_create_farm_title(),
+					editTitle: m.editor_edit_farm_title(),
+					contactHref: routeBuilders.farm.contact,
+					save: (data: MainEntryFormData, id?: string) =>
+						id ? updateFarm(id, mapFarmPayload(data)) : createFarm(mapFarmPayload(data)),
+					// Farms have no equivalent of the initiative intro copy.
+					intro: undefined
+				}
+			: {
+					createTitle: m.editor_create_initiative_title(),
+					editTitle: m.editor_edit_initiative_title(),
+					contactHref: routeBuilders.initiative.contact,
+					save: (data: MainEntryFormData, id?: string) =>
+						id
+							? updateInitiative(id, mapInitiativePayload(data))
+							: createInitiative(mapInitiativePayload(data)),
+					intro: m.editor_initiative_intro()
+				}
+	);
+
+	const isCreate = $derived(!entry);
+	const properties = $derived(entry?.properties.type === entryType ? entry.properties : undefined);
+	const icon = $derived(getPlaceIcon(entryType));
+	const hasUnsavedChanges = $derived(hasTaintedField($tainted));
+	// Header meta (F12.1): location and website live in the drawer header.
+	const address = $derived(properties ? formatEntryAddress(properties) : '');
+	const websiteUrl = $derived(properties?.url ? safeHttpUrl(properties.url) : undefined);
+	const sectionContext = $derived({ form, properties });
+
+	async function handleShare() {
+		const ok = await copyProfileLink();
+		if (ok) {
+			toastSuccess(m.entry_share_copied());
+		} else {
+			toastError(m.entry_share_failed());
+		}
+	}
+
+	// Save-bar error indicator (Feature 9.4): map each section to its fields so
+	// the sticky bar can name which sections still have validation errors. The
+	// titles match the canonical section headings (DESIGN.md, F4.1).
+	const sectionErrors = $derived(
+		sectionsWithErrors($errors as Record<string, unknown>, [
+			{ title: m.editor_section_identity(), fields: IDENTITY_FIELD_KEYS },
+			{ title: m.editor_section_description(), fields: ['description'] },
+			...extraErrorSections
+		])
+	);
+
+	const guard = createEditorGuard({
+		isSaving: () => isSaving,
+		hasUnsavedChanges: () => hasUnsavedChanges
+	});
+
+	async function handleSubmit() {
+		if (isSaving) {
+			return;
+		}
+
+		const result = await validateForm({ update: true });
+		if (!result.valid) {
+			return;
+		}
+
+		isSaving = true;
+		try {
+			let saved: MainEntryFeature;
+			if (isCreate) {
+				saved = await config.save(result.data);
+			} else {
+				const id = entry?.properties.id;
+				if (!id) {
+					throw new Error(m.editor_error_missing_entry_id());
+				}
+				saved = await config.save(result.data, id);
+			}
+
+			guard.allowNavigation();
+			toastSuccess(isCreate ? m.editor_entry_saved_created() : m.editor_entry_saved_updated());
+			await onSaved?.(saved);
+		} catch (error) {
+			guard.blockNavigation();
+			toastError(resolveApiErrorMessage(error, m.editor_save_failed()));
+		} finally {
+			isSaving = false;
+		}
+	}
+
+	async function handleCancel() {
+		if (guard.shouldBlockNavigation && !(await guard.confirmDiscardChanges())) {
+			return;
+		}
+
+		guard.allowNavigation();
+		try {
+			await onCancel?.();
+		} catch (error) {
+			guard.blockNavigation();
+			throw error;
+		}
+	}
+
+	function handleFormSubmit(event: SubmitEvent) {
+		event.preventDefault();
+		void handleSubmit();
+	}
+
+	const title = $derived(isCreate ? config.createTitle : (properties?.name ?? config.editTitle));
+</script>
+
+<Sidebar.Header class="border-b border-separator p-2">
+	<div class="flex items-start justify-between gap-2">
+		<div class="flex min-w-0 flex-1 items-start gap-3">
+			<div class="shrink-0 text-muted-foreground">
+				<img class="size-9 object-contain" src={icon} alt={title} />
+			</div>
+			<div class="mt-1 flex min-w-0 flex-1 flex-col gap-1">
+				<!-- The entry name is the header heading in both modes (F4.2); the
+				     editable name field lives inside the Identity section. -->
+				<h2 class="text-lg leading-tight font-semibold text-foreground">{title}</h2>
+				{#if mode === 'read'}
+					{#if address}
+						<Paragraph size="small" muted data-testid="entry-detail-address">
+							{address}
+						</Paragraph>
+					{/if}
+					{#if websiteUrl}
+						<a
+							href={websiteUrl}
+							target="_blank"
+							rel="noopener noreferrer"
+							data-testid="entry-detail-website"
+							class="flex w-fit max-w-full items-center gap-1 text-sm text-primary hover:underline"
+						>
+							<span class="truncate">{websiteUrl}</span>
+							<ExternalLinkIcon class="size-3 shrink-0" />
+						</a>
+					{/if}
+					{@render headerMeta?.()}
+				{/if}
+			</div>
+		</div>
+		<!-- Edit mode keeps a single Cancel affordance in the sticky save bar (F4.3). -->
+		{#if mode === 'read'}
+			<div class="flex shrink-0 items-center gap-1">
+				{#if canEdit && onEdit}
+					<AppButton variant="outline" data-testid="entry-detail-edit" onclick={onEdit}>
+						{m.map_sidebar_action_edit()}
+					</AppButton>
+				{/if}
+				<IconButton
+					class="shrink-0"
+					data-testid="entry-detail-share"
+					label={m.entry_share_action()}
+					onclick={() => void handleShare()}
+				>
+					<LinkIcon />
+				</IconButton>
+				<IconButton
+					class="shrink-0"
+					data-testid="entry-detail-close"
+					label={m.map_token_feedback_dismiss()}
+					onclick={onClose}
+				>
+					<XIcon />
+				</IconButton>
+			</div>
+		{/if}
+	</div>
+</Sidebar.Header>
+
+<SidebarScrollArea>
+	{#if mode === 'edit'}
+		<form class="flex flex-col p-4 pb-24" data-testid="entry-editor" onsubmit={handleFormSubmit}>
+			<Paragraph size="small" class={config.intro ? 'pb-1' : 'pb-6'}>
+				{m.user_form_required_fields()}
+			</Paragraph>
+			{#if config.intro}
+				<Paragraph size="small" class="pb-6">{config.intro}</Paragraph>
+			{/if}
+
+			<!-- Same section sequence and divider rhythm as read mode (F4.2 parity);
+			     only the section bodies swap to form controls. -->
+			<div class="flex flex-col [&>*]:py-6 [&>*:first-child]:pt-0 [&>*:last-child]:pb-0">
+				<IdentitySection mode="edit" {form} markerType={entryType} />
+				<DescriptionSection mode="edit" {form} />
+				<EditorAccountInfo />
+				{@render editSections(sectionContext)}
+			</div>
+
+			<EditorSaveBar {isSaving} {sectionErrors} onCancel={() => void handleCancel()} />
+		</form>
+	{:else}
+		<!-- Identity (name/location/website) lives in the drawer header in read
+		     mode; the Identity section only appears in edit mode. -->
+		<div class="flex flex-col p-4 [&>*]:py-6 [&>*:first-child]:pt-0 [&>*:last-child]:pb-0">
+			<DescriptionSection mode="read" {properties} {form} />
+			{@render readSections(sectionContext)}
+		</div>
+	{/if}
+</SidebarScrollArea>
+
+<!-- Feature 5.3: the CTA is hidden on entries the current account owns
+     (`canEdit`), who edit rather than contact themselves. -->
+{#if mode === 'read' && properties && !canEdit}
+	<Sidebar.Footer class="border-t border-separator p-2">
+		<AppButton
+			type="button"
+			class="w-full"
+			data-testid="entry-contact-toggle"
+			onclick={() => void goto(config.contactHref(properties.id))}
+		>
+			{m.entry_contact_button()}
+		</AppButton>
+	</Sidebar.Footer>
+{/if}

--- a/packages/map-next/src/lib/components/domain/entries/index.ts
+++ b/packages/map-next/src/lib/components/domain/entries/index.ts
@@ -11,6 +11,9 @@ import ProfileSkeleton from './ProfileSkeleton.svelte';
 import IdentitySection from './sections/IdentitySection.svelte';
 import DescriptionSection from './sections/DescriptionSection.svelte';
 import BadgesSection from './sections/BadgesSection.svelte';
+import EntryProfile from './EntryProfile.svelte';
+
+export type { EntryProfileProps, EntryProfileSectionContext } from './EntryProfile.svelte';
 
 export {
 	BadgesList,
@@ -25,5 +28,6 @@ export {
 	ProfileSkeleton,
 	IdentitySection,
 	DescriptionSection,
-	BadgesSection
+	BadgesSection,
+	EntryProfile
 };

--- a/packages/map-next/src/lib/components/domain/farms/FarmProfile.svelte
+++ b/packages/map-next/src/lib/components/domain/farms/FarmProfile.svelte
@@ -1,24 +1,8 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
-	import XIcon from '@lucide/svelte/icons/x';
-	import LinkIcon from '@lucide/svelte/icons/link';
-	import ExternalLinkIcon from '@lucide/svelte/icons/external-link';
-	import { defaults, superForm } from 'sveltekit-superforms';
-	import { zod4, zod4Client } from 'sveltekit-superforms/adapters';
-	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
-	import { SidebarScrollArea } from '$lib/components/layout';
-	import { AppButton, IconButton } from '$lib/components/actions';
 	import { Paragraph } from '$lib/components/typography';
-	import { EditorAccountInfo, EditorSaveBar } from '$lib/components/forms';
-	import {
-		IdentitySection,
-		DescriptionSection,
-		BadgesSection
-	} from '$lib/components/domain/entries';
-	import { formatFoundedLine, formatEntryAddress } from '$lib/utils/entry-format';
-	import { safeHttpUrl } from '$lib/utils/url';
-	import { copyProfileLink } from '$lib/utils/share';
-	import { routeBuilders } from '$lib/utils/routes';
+	import { BadgesSection, EntryProfile } from '$lib/components/domain/entries';
+	import type { EntryProfileSectionContext } from '$lib/components/domain/entries';
+	import { formatFoundedLine } from '$lib/utils/entry-format';
 	import {
 		FarmProductsSection,
 		FarmEconomicBehaviorSection,
@@ -26,19 +10,8 @@
 		FarmDepotsSection
 	} from './sections';
 	import * as m from '$lib/paraglide/messages.js';
-	import { resolveApiErrorMessage } from '$lib/utils/api-error';
-	import { getPlaceIcon } from '$lib/utils/marker-icons';
-	import type { DepotFeature, MainEntryFeature } from '$lib/types/entries';
+	import type { DepotFeature, MainEntryFeature, MainEntryProperties } from '$lib/types/entries';
 	import type { EntryEditorData } from '$lib/types/editor';
-	import { createFarm, updateFarm } from '$lib/api/entry-mutations';
-	import { createEditorGuard } from '$lib/utils/editor-guard.svelte';
-	import { hasTaintedField, sectionsWithErrors, IDENTITY_FIELD_KEYS } from '$lib/utils/editor-form';
-	import { toastSuccess, toastError } from '$lib/utils/toast';
-	import {
-		mainEntryFormFromFeature,
-		mainEntryFormSchema,
-		mapFarmPayload
-	} from '$lib/utils/editor-schema';
 
 	interface FarmProfileProps {
 		/** The farm feature; undefined only when creating a new farm. */
@@ -75,245 +48,73 @@
 		onAddDepot
 	}: FarmProfileProps = $props();
 
-	// Remounted (via `{#key}` in the parent) whenever the farm or mode changes,
-	// so form state is initialised directly from props.
-	// svelte-ignore state_referenced_locally
-	const form = superForm(defaults(mainEntryFormFromFeature(entry), zod4(mainEntryFormSchema)), {
-		validators: zod4Client(mainEntryFormSchema),
-		SPA: true,
-		dataType: 'json'
-	});
-	const { errors, tainted, validateForm } = form;
-
-	let isSaving = $state(false);
-
-	const isCreate = $derived(!entry);
-	const properties = $derived(entry?.properties.type === 'Farm' ? entry.properties : undefined);
-	const icon = $derived(getPlaceIcon('Farm'));
 	const products = $derived(editorData?.products ?? []);
 	const badges = $derived(editorData?.badges ?? []);
-	const hasUnsavedChanges = $derived(hasTaintedField($tainted));
-	// Header meta (F12.1): founded line, location, and website live in the drawer
-	// header. The membership status chip moved into the Membership section.
-	const foundedLine = $derived(properties ? formatFoundedLine(properties) : '');
-	const address = $derived(properties ? formatEntryAddress(properties) : '');
-	const websiteUrl = $derived(properties?.url ? safeHttpUrl(properties.url) : undefined);
 
-	async function handleShare() {
-		const ok = await copyProfileLink();
-		if (ok) {
-			toastSuccess(m.entry_share_copied());
-		} else {
-			toastError(m.entry_share_failed());
+	const farmProperties = (properties?: MainEntryProperties) =>
+		properties?.type === 'Farm' ? properties : undefined;
+
+	// The membership status chip lives in the Membership section; only the
+	// founded line is added to the shared drawer header (F12.1).
+	const ownProperties = $derived(farmProperties(entry?.properties));
+	const foundedLine = $derived(ownProperties ? formatFoundedLine(ownProperties) : '');
+
+	const errorSections = $derived([
+		{ title: m.editor_section_products(), fields: ['additionalProductInformation'] },
+		{ title: m.editor_section_economic(), fields: ['economicalBehavior'] },
+		{
+			title: m.editor_section_membership(),
+			fields: ['foundedAtMonth', 'maximumMembers', 'participation']
 		}
-	}
-
-	// Save-bar error indicator (Feature 9.4): map each section to its fields so
-	// the sticky bar can name which sections still have validation errors. The
-	// titles match the canonical section headings (DESIGN.md, F4.1).
-	const sectionErrors = $derived(
-		sectionsWithErrors($errors as Record<string, unknown>, [
-			{ title: m.editor_section_identity(), fields: IDENTITY_FIELD_KEYS },
-			{ title: m.editor_section_description(), fields: ['description'] },
-			{ title: m.editor_section_products(), fields: ['additionalProductInformation'] },
-			{ title: m.editor_section_economic(), fields: ['economicalBehavior'] },
-			{
-				title: m.editor_section_membership(),
-				fields: ['foundedAtMonth', 'maximumMembers', 'participation']
-			}
-		])
-	);
-
-	const guard = createEditorGuard({
-		isSaving: () => isSaving,
-		hasUnsavedChanges: () => hasUnsavedChanges
-	});
-
-	async function handleSubmit() {
-		if (isSaving) {
-			return;
-		}
-
-		const result = await validateForm({ update: true });
-		if (!result.valid) {
-			return;
-		}
-
-		isSaving = true;
-		try {
-			const payload = mapFarmPayload(result.data);
-			let saved: MainEntryFeature;
-			if (isCreate) {
-				saved = await createFarm(payload);
-			} else {
-				const id = entry?.properties.id;
-				if (!id) {
-					throw new Error(m.editor_error_missing_entry_id());
-				}
-				saved = await updateFarm(id, payload);
-			}
-
-			guard.allowNavigation();
-			toastSuccess(isCreate ? m.editor_entry_saved_created() : m.editor_entry_saved_updated());
-			await onSaved?.(saved);
-		} catch (error) {
-			guard.blockNavigation();
-			toastError(resolveApiErrorMessage(error, m.editor_save_failed()));
-		} finally {
-			isSaving = false;
-		}
-	}
-
-	async function handleCancel() {
-		if (guard.shouldBlockNavigation && !(await guard.confirmDiscardChanges())) {
-			return;
-		}
-
-		guard.allowNavigation();
-		try {
-			await onCancel?.();
-		} catch (error) {
-			guard.blockNavigation();
-			throw error;
-		}
-	}
-
-	function handleFormSubmit(event: SubmitEvent) {
-		event.preventDefault();
-		void handleSubmit();
-	}
-
-	const title = $derived(
-		isCreate ? m.editor_create_farm_title() : (properties?.name ?? m.editor_edit_farm_title())
-	);
+	]);
 </script>
 
-<Sidebar.Header class="border-b border-separator p-2">
-	<div class="flex items-start justify-between gap-2">
-		<div class="flex min-w-0 flex-1 items-start gap-3">
-			<div class="shrink-0 text-muted-foreground">
-				<img class="size-9 object-contain" src={icon} alt={title} />
-			</div>
-			<div class="mt-1 flex min-w-0 flex-1 flex-col gap-1">
-				<!-- The entry name is the header heading in both modes (F4.2); the
-				     editable name field lives inside the Identity section. -->
-				<h2 class="text-lg leading-tight font-semibold text-foreground">{title}</h2>
-				{#if mode === 'read'}
-					{#if address}
-						<Paragraph size="small" muted data-testid="entry-detail-address">
-							{address}
-						</Paragraph>
-					{/if}
-					{#if websiteUrl}
-						<a
-							href={websiteUrl}
-							target="_blank"
-							rel="noopener noreferrer"
-							data-testid="entry-detail-website"
-							class="flex w-fit max-w-full items-center gap-1 text-sm text-primary hover:underline"
-						>
-							<span class="truncate">{websiteUrl}</span>
-							<ExternalLinkIcon class="size-3 shrink-0" />
-						</a>
-					{/if}
-					{#if foundedLine}
-						<Paragraph size="small" muted>{foundedLine}</Paragraph>
-					{/if}
-				{/if}
-			</div>
-		</div>
-		<!-- Edit mode keeps a single Cancel affordance in the sticky save bar (F4.3). -->
-		{#if mode === 'read'}
-			<div class="flex shrink-0 items-center gap-1">
-				{#if canEdit && onEdit}
-					<AppButton variant="outline" data-testid="entry-detail-edit" onclick={onEdit}>
-						{m.map_sidebar_action_edit()}
-					</AppButton>
-				{/if}
-				<IconButton
-					class="shrink-0"
-					data-testid="entry-detail-share"
-					label={m.entry_share_action()}
-					onclick={() => void handleShare()}
-				>
-					<LinkIcon />
-				</IconButton>
-				<IconButton
-					class="shrink-0"
-					data-testid="entry-detail-close"
-					label={m.map_token_feedback_dismiss()}
-					onclick={onClose}
-				>
-					<XIcon />
-				</IconButton>
-			</div>
+<EntryProfile
+	entryType="Farm"
+	{entry}
+	{mode}
+	{canEdit}
+	{onClose}
+	{onEdit}
+	{onCancel}
+	{onSaved}
+	extraErrorSections={errorSections}
+>
+	{#snippet headerMeta()}
+		{#if foundedLine}
+			<Paragraph size="small" muted>{foundedLine}</Paragraph>
 		{/if}
-	</div>
-</Sidebar.Header>
+	{/snippet}
 
-<SidebarScrollArea>
-	{#if mode === 'edit'}
-		<form class="flex flex-col p-4 pb-24" data-testid="entry-editor" onsubmit={handleFormSubmit}>
-			<Paragraph size="small" class="pb-6">{m.user_form_required_fields()}</Paragraph>
+	{#snippet editSections({ form, properties }: EntryProfileSectionContext)}
+		<FarmProductsSection mode="edit" {form} {products} />
+		<FarmEconomicBehaviorSection mode="edit" {form} />
+		<FarmMembershipSection mode="edit" {form} />
+		<BadgesSection mode="edit" {form} {badges} idPrefix="farm-badge" />
+		<FarmDepotsSection
+			properties={farmProperties(properties)}
+			{ownedDepotIds}
+			isFarmOwner={canEdit}
+			{onDepotSelect}
+			{onDepotEdit}
+			{onDepotDelete}
+			{onAddDepot}
+		/>
+	{/snippet}
 
-			<!-- Same section sequence and divider rhythm as read mode (F4.2 parity);
-			     only the section bodies swap to form controls. -->
-			<div class="flex flex-col divide-y [&>*]:py-6 [&>*:first-child]:pt-0 [&>*:last-child]:pb-0">
-				<IdentitySection mode="edit" {form} markerType="Farm" />
-				<DescriptionSection mode="edit" {form} />
-				<EditorAccountInfo />
-				<FarmProductsSection mode="edit" {form} {products} />
-				<FarmEconomicBehaviorSection mode="edit" {form} />
-				<FarmMembershipSection mode="edit" {form} />
-				<BadgesSection mode="edit" {form} {badges} idPrefix="farm-badge" />
-				<FarmDepotsSection
-					{properties}
-					{ownedDepotIds}
-					isFarmOwner={canEdit}
-					{onDepotSelect}
-					{onDepotEdit}
-					{onDepotDelete}
-					{onAddDepot}
-				/>
-			</div>
-
-			<EditorSaveBar {isSaving} {sectionErrors} onCancel={() => void handleCancel()} />
-		</form>
-	{:else}
-		<!-- Identity (name/location/website) lives in the drawer header in read
-		     mode; the Identity section only appears in edit mode. `divide-y`
-		     draws separators only between rendered sections, so empty sections
-		     produce no stray dividers (F12.2). -->
-		<div class="flex flex-col p-4 [&>*]:py-6 [&>*:first-child]:pt-0 [&>*:last-child]:pb-0">
-			<DescriptionSection mode="read" {properties} {form} />
-			<FarmProductsSection mode="read" {properties} {form} />
-			<FarmEconomicBehaviorSection mode="read" {properties} {form} />
-			<FarmMembershipSection mode="read" {properties} {form} />
-			<BadgesSection mode="read" {properties} {form} idPrefix="farm-badge" />
-			<FarmDepotsSection
-				{properties}
-				{ownedDepotIds}
-				isFarmOwner={canEdit}
-				{onDepotSelect}
-				{onDepotEdit}
-				{onDepotDelete}
-				{onAddDepot}
-			/>
-		</div>
-	{/if}
-</SidebarScrollArea>
-
-<!-- Feature 5.3: the CTA is hidden on entries the current account owns
-     (`canEdit`), who edit rather than contact themselves. -->
-{#if mode === 'read' && properties && !canEdit}
-	<Sidebar.Footer class="border-t border-separator p-2">
-		<AppButton
-			type="button"
-			class="w-full"
-			data-testid="entry-contact-toggle"
-			onclick={() => void goto(routeBuilders.farm.contact(properties.id))}
-		>
-			{m.entry_contact_button()}
-		</AppButton>
-	</Sidebar.Footer>
-{/if}
+	{#snippet readSections({ form, properties }: EntryProfileSectionContext)}
+		<FarmProductsSection mode="read" properties={farmProperties(properties)} {form} />
+		<FarmEconomicBehaviorSection mode="read" properties={farmProperties(properties)} {form} />
+		<FarmMembershipSection mode="read" properties={farmProperties(properties)} {form} />
+		<BadgesSection mode="read" {properties} {form} idPrefix="farm-badge" />
+		<FarmDepotsSection
+			properties={farmProperties(properties)}
+			{ownedDepotIds}
+			isFarmOwner={canEdit}
+			{onDepotSelect}
+			{onDepotEdit}
+			{onDepotDelete}
+			{onAddDepot}
+		/>
+	{/snippet}
+</EntryProfile>

--- a/packages/map-next/src/lib/components/domain/initiatives/InitiativeProfile.svelte
+++ b/packages/map-next/src/lib/components/domain/initiatives/InitiativeProfile.svelte
@@ -1,39 +1,9 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
-	import XIcon from '@lucide/svelte/icons/x';
-	import LinkIcon from '@lucide/svelte/icons/link';
-	import ExternalLinkIcon from '@lucide/svelte/icons/external-link';
-	import { defaults, superForm } from 'sveltekit-superforms';
-	import { zod4, zod4Client } from 'sveltekit-superforms/adapters';
-	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
-	import { SidebarScrollArea } from '$lib/components/layout';
-	import { AppButton, IconButton } from '$lib/components/actions';
-	import { Paragraph } from '$lib/components/typography';
-	import { EditorAccountInfo, EditorSaveBar } from '$lib/components/forms';
-	import {
-		IdentitySection,
-		DescriptionSection,
-		BadgesSection
-	} from '$lib/components/domain/entries';
-	import { formatEntryAddress } from '$lib/utils/entry-format';
-	import { safeHttpUrl } from '$lib/utils/url';
-	import { copyProfileLink } from '$lib/utils/share';
-	import { routeBuilders } from '$lib/utils/routes';
+	import { BadgesSection, EntryProfile } from '$lib/components/domain/entries';
+	import type { EntryProfileSectionContext } from '$lib/components/domain/entries';
 	import { InitiativeGoalsSection } from './sections';
-	import * as m from '$lib/paraglide/messages.js';
-	import { resolveApiErrorMessage } from '$lib/utils/api-error';
-	import { getPlaceIcon } from '$lib/utils/marker-icons';
-	import type { MainEntryFeature } from '$lib/types/entries';
+	import type { MainEntryFeature, MainEntryProperties } from '$lib/types/entries';
 	import type { EntryEditorData } from '$lib/types/editor';
-	import { createInitiative, updateInitiative } from '$lib/api/entry-mutations';
-	import { createEditorGuard } from '$lib/utils/editor-guard.svelte';
-	import { hasTaintedField, sectionsWithErrors, IDENTITY_FIELD_KEYS } from '$lib/utils/editor-form';
-	import { toastSuccess, toastError } from '$lib/utils/toast';
-	import {
-		mainEntryFormFromFeature,
-		mainEntryFormSchema,
-		mapInitiativePayload
-	} from '$lib/utils/editor-schema';
 
 	interface InitiativeProfileProps {
 		/** The initiative feature; undefined only when creating a new initiative. */
@@ -60,216 +30,30 @@
 		onSaved
 	}: InitiativeProfileProps = $props();
 
-	// Remounted (via `{#key}` in the parent) whenever the initiative or mode
-	// changes, so form state is initialised directly from props.
-	// svelte-ignore state_referenced_locally
-	const form = superForm(defaults(mainEntryFormFromFeature(entry), zod4(mainEntryFormSchema)), {
-		validators: zod4Client(mainEntryFormSchema),
-		SPA: true,
-		dataType: 'json'
-	});
-	const { errors, tainted, validateForm } = form;
-
-	let isSaving = $state(false);
-
-	const isCreate = $derived(!entry);
-	const properties = $derived(
-		entry?.properties.type === 'Initiative' ? entry.properties : undefined
-	);
-	const icon = $derived(getPlaceIcon('Initiative'));
-	// Header meta: location and website live in the drawer header in read mode.
-	const address = $derived(properties ? formatEntryAddress(properties) : '');
-	const websiteUrl = $derived(properties?.url ? safeHttpUrl(properties.url) : undefined);
 	const goals = $derived(editorData?.goals ?? []);
 	const badges = $derived(editorData?.badges ?? []);
-	const hasUnsavedChanges = $derived(hasTaintedField($tainted));
 
-	async function handleShare() {
-		const ok = await copyProfileLink();
-		if (ok) {
-			toastSuccess(m.entry_share_copied());
-		} else {
-			toastError(m.entry_share_failed());
-		}
-	}
-
-	// Save-bar error indicator (Feature 9.4): initiatives only expose the
-	// identity and description sections that can carry field-level errors.
-	const sectionErrors = $derived(
-		sectionsWithErrors($errors as Record<string, unknown>, [
-			{ title: m.editor_section_identity(), fields: IDENTITY_FIELD_KEYS },
-			{ title: m.editor_section_description(), fields: ['description'] }
-		])
-	);
-
-	const guard = createEditorGuard({
-		isSaving: () => isSaving,
-		hasUnsavedChanges: () => hasUnsavedChanges
-	});
-
-	async function handleSubmit() {
-		if (isSaving) {
-			return;
-		}
-
-		const result = await validateForm({ update: true });
-		if (!result.valid) {
-			return;
-		}
-
-		isSaving = true;
-		try {
-			const payload = mapInitiativePayload(result.data);
-			let saved: MainEntryFeature;
-			if (isCreate) {
-				saved = await createInitiative(payload);
-			} else {
-				const id = entry?.properties.id;
-				if (!id) {
-					throw new Error(m.editor_error_missing_entry_id());
-				}
-				saved = await updateInitiative(id, payload);
-			}
-
-			guard.allowNavigation();
-			toastSuccess(isCreate ? m.editor_entry_saved_created() : m.editor_entry_saved_updated());
-			await onSaved?.(saved);
-		} catch (error) {
-			guard.blockNavigation();
-			toastError(resolveApiErrorMessage(error, m.editor_save_failed()));
-		} finally {
-			isSaving = false;
-		}
-	}
-
-	async function handleCancel() {
-		if (guard.shouldBlockNavigation && !(await guard.confirmDiscardChanges())) {
-			return;
-		}
-
-		guard.allowNavigation();
-		try {
-			await onCancel?.();
-		} catch (error) {
-			guard.blockNavigation();
-			throw error;
-		}
-	}
-
-	function handleFormSubmit(event: SubmitEvent) {
-		event.preventDefault();
-		void handleSubmit();
-	}
-
-	const title = $derived(
-		isCreate
-			? m.editor_create_initiative_title()
-			: (properties?.name ?? m.editor_edit_initiative_title())
-	);
+	const initiativeProperties = (properties?: MainEntryProperties) =>
+		properties?.type === 'Initiative' ? properties : undefined;
 </script>
 
-<Sidebar.Header class="border-b border-separator">
-	<div class="flex items-start justify-between gap-2">
-		<div class="flex min-w-0 flex-1 items-start gap-3">
-			<div class="shrink-0 text-muted-foreground">
-				<img class="size-9 object-contain" src={icon} alt={title} />
-			</div>
-			<div class="mt-1 flex min-w-0 flex-1 flex-col gap-1">
-				<!-- The entry name is the header heading in both modes (F4.2); the
-				     editable name field lives inside the Identity section. -->
-				<h2 class="text-lg leading-tight font-semibold text-foreground">{title}</h2>
-				{#if mode === 'read'}
-					{#if address}
-						<Paragraph size="small" muted data-testid="entry-detail-address">
-							{address}
-						</Paragraph>
-					{/if}
-					{#if websiteUrl}
-						<a
-							href={websiteUrl}
-							target="_blank"
-							rel="noopener noreferrer"
-							data-testid="entry-detail-website"
-							class="flex w-fit max-w-full items-center gap-1 text-sm text-primary hover:underline"
-						>
-							<span class="truncate">{websiteUrl}</span>
-							<ExternalLinkIcon class="size-3 shrink-0" />
-						</a>
-					{/if}
-				{/if}
-			</div>
-		</div>
-		<!-- Edit mode keeps a single Cancel affordance in the sticky save bar (F4.3). -->
-		{#if mode === 'read'}
-			<div class="flex shrink-0 items-center gap-1">
-				{#if canEdit && onEdit}
-					<AppButton variant="outline" data-testid="entry-detail-edit" onclick={onEdit}>
-						{m.map_sidebar_action_edit()}
-					</AppButton>
-				{/if}
-				<IconButton
-					class="shrink-0"
-					data-testid="entry-detail-share"
-					label={m.entry_share_action()}
-					onclick={() => void handleShare()}
-				>
-					<LinkIcon />
-				</IconButton>
-				<IconButton
-					class="shrink-0"
-					data-testid="entry-detail-close"
-					label={m.map_token_feedback_dismiss()}
-					onclick={onClose}
-				>
-					<XIcon />
-				</IconButton>
-			</div>
-		{/if}
-	</div>
-</Sidebar.Header>
+<EntryProfile
+	entryType="Initiative"
+	{entry}
+	{mode}
+	{canEdit}
+	{onClose}
+	{onEdit}
+	{onCancel}
+	{onSaved}
+>
+	{#snippet editSections({ form }: EntryProfileSectionContext)}
+		<InitiativeGoalsSection mode="edit" {form} {goals} />
+		<BadgesSection mode="edit" {form} {badges} idPrefix="initiative-badge" />
+	{/snippet}
 
-<SidebarScrollArea>
-	{#if mode === 'edit'}
-		<form class="flex flex-col p-4 pb-24" data-testid="entry-editor" onsubmit={handleFormSubmit}>
-			<Paragraph size="small" class="pb-1">{m.user_form_required_fields()}</Paragraph>
-			<Paragraph size="small" class="pb-6">{m.editor_initiative_intro()}</Paragraph>
-
-			<!-- Same section sequence and divider rhythm as read mode (F4.2 parity);
-			     only the section bodies swap to form controls. -->
-			<div class="flex flex-col [&>*]:py-6 [&>*:first-child]:pt-0 [&>*:last-child]:pb-0">
-				<IdentitySection mode="edit" {form} markerType="Initiative" />
-				<DescriptionSection mode="edit" {form} />
-				<EditorAccountInfo />
-				<InitiativeGoalsSection mode="edit" {form} {goals} />
-				<BadgesSection mode="edit" {form} {badges} idPrefix="initiative-badge" />
-			</div>
-
-			<EditorSaveBar {isSaving} {sectionErrors} onCancel={() => void handleCancel()} />
-		</form>
-	{:else}
-		<!-- Identity (name/location/website) lives in the drawer header in read
-		     mode; the Identity section only appears in edit mode. `divide-y`
-		     draws separators only between rendered sections, so empty sections
-		     produce no stray dividers (F12.2). -->
-		<div class="flex flex-col p-4 [&>*]:py-6 [&>*:first-child]:pt-0 [&>*:last-child]:pb-0">
-			<DescriptionSection mode="read" {properties} {form} />
-			<InitiativeGoalsSection mode="read" {properties} {form} />
-			<BadgesSection mode="read" {properties} {form} idPrefix="initiative-badge" />
-		</div>
-	{/if}
-</SidebarScrollArea>
-
-<!-- Feature 5.3: the CTA is hidden on entries the current account owns
-     (`canEdit`), who edit rather than contact themselves. -->
-{#if mode === 'read' && properties && !canEdit}
-	<Sidebar.Footer class="border-t border-separator p-4">
-		<AppButton
-			type="button"
-			class="w-full"
-			data-testid="entry-contact-toggle"
-			onclick={() => void goto(routeBuilders.initiative.contact(properties.id))}
-		>
-			{m.entry_contact_button()}
-		</AppButton>
-	</Sidebar.Footer>
-{/if}
+	{#snippet readSections({ form, properties }: EntryProfileSectionContext)}
+		<InitiativeGoalsSection mode="read" properties={initiativeProperties(properties)} {form} />
+		<BadgesSection mode="read" {properties} {form} idPrefix="initiative-badge" />
+	{/snippet}
+</EntryProfile>

--- a/packages/map-next/src/lib/components/domain/map/SymbolMarkerCluster.svelte
+++ b/packages/map-next/src/lib/components/domain/map/SymbolMarkerCluster.svelte
@@ -80,12 +80,12 @@
 		(feature.properties?.point_count_abbreviated as string | undefined) ?? String(pointCount)
 	);
 
-	// Calculate circle positions for icons
+	// Icons are laid out evenly around a ring whose radius grows with the count.
 	function getCirclePosition(index: number, total: number): { x: number; y: number } {
 		if (index === 0 && total === 1) return { x: 0, y: 0 };
 
-		const radius = spreadRadius(total); // Radius increases with number of points
-		const angle = (index * 2 * Math.PI) / total; // Evenly distribute around the circle
+		const radius = spreadRadius(total);
+		const angle = (index * 2 * Math.PI) / total;
 
 		return {
 			x: Math.cos(angle) * radius,

--- a/packages/map-next/src/lib/components/domain/map/SymbolMarkerLayer.svelte
+++ b/packages/map-next/src/lib/components/domain/map/SymbolMarkerLayer.svelte
@@ -17,14 +17,12 @@
 	let { onMarkerClick, minzoom, highlightedIds, selectedKey }: SymbolMarkerLayerProps = $props();
 </script>
 
-<!-- Cluster markers -->
 <MarkerLayer applyToClusters {minzoom}>
 	{#snippet children({ feature })}
 		<SymbolMarkerCluster {feature} {onMarkerClick} {highlightedIds} {selectedKey} />
 	{/snippet}
 </MarkerLayer>
 
-<!-- Individual markers -->
 <MarkerLayer applyToClusters={false} {minzoom}>
 	{#snippet children({ feature })}
 		{@const entry = asEntryFeature(feature)}

--- a/packages/map-next/src/lib/components/layout/TwoColumnLayout.svelte
+++ b/packages/map-next/src/lib/components/layout/TwoColumnLayout.svelte
@@ -13,7 +13,6 @@
 </script>
 
 <div class={cn('grid h-full lg:grid-cols-2', className ? className : 'min-h-screen')}>
-	<!-- Left Column - Information (hidden on mobile, visible on lg+) -->
 	<div class="relative hidden flex-col justify-start p-8 lg:flex lg:p-16">
 		<div class="relative z-10 mx-auto flex max-w-xl flex-col gap-10">
 			{#if leftColumn}
@@ -23,7 +22,6 @@
 			{/if}
 		</div>
 	</div>
-	<!-- Right Column - Form -->
 	<div
 		class="relative flex styled-scrollbar min-h-0 flex-col items-center justify-start overflow-y-auto bg-auth-panel p-4 sm:p-6 lg:p-16"
 	>

--- a/packages/map-next/src/lib/design/map-style.ts
+++ b/packages/map-next/src/lib/design/map-style.ts
@@ -29,109 +29,43 @@ function createDefaultColors(theme: MapDesignTokens): StyleBuilderColors {
 	const map = createMapColorScale(theme.baseColor);
 
 	return {
-		/** Color for land areas on the map. */
 		land: map[450],
-
-		/** Color for water bodies like lakes and rivers. */
 		water: map[500],
-
-		/** Color for glacier areas, usually shown as white. */
 		glacier: map[400],
-
-		/** Color for wooded or forested areas. */
 		wood: map[400],
-
-		/** Color for grasslands or open fields. */
 		grass: map[400],
-
-		/** Color for parks and recreational areas. */
 		park: map[400],
-
-		/** Color used for parking areas. */
 		parking: map[350],
-
-		/** Color used for footpaths and pedestrian areas. */
 		foot: map[300],
-
-		/** Color used for cycle paths. */
 		cycle: map[300],
-
-		/** Color for streets, roads, motorways. */
 		street: map[350],
-
-		/** Background color for streets. */
 		streetbg: map[450],
-
-		/** Color for trunks. */
 		trunk: map[350],
-
-		/** Background color for trunks. */
 		trunkbg: map[450],
-
-		/** Color for motorways. */
 		motorway: map[350],
-
-		/** Background color for motorways. */
 		motorwaybg: map[450],
-
-		/** Background color for buildings. */
 		buildingbg: map[450],
-
-		/** Color used for boundaries. */
 		boundary: map[600],
-
-		/** Color used for disputed boundaries. */
 		disputed: map[600],
-
-		/** Primary color for buildings. */
 		building: map[400],
-
-		/** Color used for residential areas. */
 		residential: map[400],
-
-		/** Color used for commercial areas. */
 		commercial: map[400],
-
-		/** Color used for industrial areas. */
 		industrial: map[400],
-
-		/** Primary color used for labels. */
 		label: map[850],
-
-		/** Color used for label halos. */
 		labelHalo: map[400],
-
-		/** Color used for agriculture areas. */
 		agriculture: map[400],
-
-		/** Color used for railways. */
 		rail: map[450],
-
-		/** Color used for subways. */
 		subway: map[450],
-
-		/** Color used for waste areas. */
 		waste: map[400],
-
-		/** Color used for burial and cemetery areas. */
 		burial: map[400],
-
-		/** Color used for sand areas like beaches. */
 		sand: map[400],
-
-		/** Color used for rocky terrain. */
 		rock: map[400],
-
-		/** Color used for leisure areas like parks and gardens. */
 		leisure: map[400],
-
-		/** Color used for wetland areas like marshes. */
 		wetland: map[400],
-
-		/** Color indicating danger or warning areas. */
 		danger: map[300],
 
-		// Placeholder colors for future use - currently not implemented
+		// Required by StyleBuilderColors but not part of the design yet — these
+		// features are not styled deliberately, they just take the base shade.
 		symbol: map[500],
 		shield: map[500],
 		prison: map[500],

--- a/packages/map-next/src/routes/+layout.svelte
+++ b/packages/map-next/src/routes/+layout.svelte
@@ -12,7 +12,6 @@
 		authStore.ensureInitialized();
 	});
 
-	// Ensure entries is always defined and reactive
 	const safeEntries = $derived.by(
 		() => data?.entries ?? { type: 'FeatureCollection', features: [] }
 	);
@@ -21,16 +20,12 @@
 <svelte:head></svelte:head>
 
 <div class="app-container" data-theme={config.theme}>
-	<!-- Always render the map as base layer -->
 	<Map entries={safeEntries} />
 
-	<!-- Render children (auth modals, etc.) on top -->
 	{@render children()}
 
-	<!-- Global confirmation dialog (replaces window.confirm) -->
 	<ConfirmDialog />
 
-	<!-- Global toast feedback -->
 	<Toaster />
 </div>
 

--- a/packages/map-next/src/routes/+page.svelte
+++ b/packages/map-next/src/routes/+page.svelte
@@ -1,6 +1,3 @@
 <script lang="ts">
-	// Root page - Map is rendered in layout
-	// This page exists for the #/ route
+	// Placeholder for the `#/` route — the map itself is rendered in +layout.svelte.
 </script>
-
-<!-- Map is rendered in +layout.svelte -->

--- a/packages/map-next/src/routes/Map.svelte
+++ b/packages/map-next/src/routes/Map.svelte
@@ -113,13 +113,9 @@
 		mapStyle = getMapStyle({ theme });
 	});
 
-	// Map instance reference
 	let map: MaplibreMap | undefined = $state();
-
-	// Sidebar reference for calling openDetailView
 	let sidebarComponent: MapSidebar | undefined = $state();
 
-	// Selected entry state for programmatic popup
 	let selectedEntry: {
 		feature: EntryFeature;
 		options?: EntryFocusOptions;
@@ -460,10 +456,7 @@
 			networkSelection.selectDepot(entry.properties.id);
 		}
 
-		// Pan map and show popup
 		focusEntry(entry, options);
-
-		// Open detail view in sidebar
 		sidebarComponent?.openDetailView(entry);
 
 		// Open the popup after a short delay to let the map start moving
@@ -562,7 +555,6 @@
 		}
 	});
 
-	// only show Farms and Initiatives
 	const primaryPlaces = $derived({
 		...mapEntries,
 		features: mapEntries.features.filter(
@@ -645,7 +637,6 @@
 			<NavigationControl position={mapControlsPosition} />
 			<GeolocateControl position={mapControlsPosition} />
 
-			<!-- Farm/initiative network visualization for the open profile -->
 			{#if networkEntry}
 				<NetworkLayer
 					entry={networkEntry}
@@ -708,7 +699,6 @@
 				/>
 			</GeoJSON>
 
-			<!-- Programmatic popup for selected entry from sidebar -->
 			{#if selectedEntry}
 				<Popup bind:isPopupOpen bind:selectedEntry onclose={handleDetailClose} />
 			{/if}

--- a/packages/map-next/src/routes/MapSidebar.svelte
+++ b/packages/map-next/src/routes/MapSidebar.svelte
@@ -101,7 +101,6 @@
 
 	const parsedRoute = $derived(parseHashRoute(page.url.hash));
 
-	// Auto-collapse when auth modal routes are active
 	const isAuthModalRoute = $derived(isAuthRouteHash(page.url.hash));
 	const routeKind = $derived(parsedRoute.kind);
 	const isUserAuthenticated = $derived(authStore.isAuthenticated);
@@ -111,19 +110,17 @@
 		isMyEntriesScope ? (myEntries?.features ?? []) : (entries?.features ?? [])
 	);
 
-	// Track previous auth route state to detect transitions
 	let wasAuthModalRoute = $state(false);
-	// Store the user's preferred collapsed state before auth modal opens
 	let collapsedBeforeAuthModal = $state(false);
 	let redirectingToSignInForMyEntries = $state(false);
 
+	// Auth modal routes force the sidebar collapsed; the user's own preference is
+	// stashed on the way in and restored on the way out.
 	$effect(() => {
 		if (isAuthModalRoute && !wasAuthModalRoute) {
-			// Entering auth route - save current state and collapse
 			collapsedBeforeAuthModal = collapsed;
 			collapsed = true;
 		} else if (!isAuthModalRoute && wasAuthModalRoute) {
-			// Leaving auth route - restore previous state
 			collapsed = collapsedBeforeAuthModal;
 		}
 		wasAuthModalRoute = isAuthModalRoute;
@@ -143,7 +140,6 @@
 		void goto(routeBuilders.auth.signInWithRedirect(routeBuilders.myEntries()));
 	});
 
-	// Detail view from route data (loaded by +page.ts)
 	const detailData = $derived(page.data.detailData);
 	const contactData = $derived(page.data.contactData);
 	const editorData = $derived(page.data.editorData);
@@ -266,7 +262,6 @@
 		}
 	});
 
-	// Track when detail route changes to trigger map pan
 	let lastDetailId = $state<string | null>(null);
 	// The contact route frames its entry exactly like the detail route, so a deep
 	// link into contact focuses the map the same way (and detail↔contact for the
@@ -292,7 +287,7 @@
 		}
 	});
 
-	// Expose function to open detail view from outside (e.g., map click)
+	// Called from outside, e.g. on a map marker click.
 	export function openDetailView(feature: EntryFeature) {
 		void handleEntryClick(feature, { triggerPan: false });
 	}

--- a/packages/map-next/src/routes/users/editaccount/+page.svelte
+++ b/packages/map-next/src/routes/users/editaccount/+page.svelte
@@ -29,7 +29,6 @@
 			});
 
 			if (response.id === data.user.id) {
-				// Success - redirect to map
 				goto(routeBuilders.home());
 			} else {
 				throw new Error(m.errors_account_update_failed());

--- a/packages/map-next/src/routes/users/editpassword/+page.svelte
+++ b/packages/map-next/src/routes/users/editpassword/+page.svelte
@@ -24,7 +24,6 @@
 				password: values.password,
 				email: data.user.email
 			});
-			// Success - redirect to map
 			goto(routeBuilders.home());
 		} catch (err) {
 			error = resolveApiErrorMessage(err, m.errors_password_change_failed());

--- a/packages/map-next/src/routes/users/resetpassword/+page.ts
+++ b/packages/map-next/src/routes/users/resetpassword/+page.ts
@@ -3,8 +3,8 @@ import { routeBuilders } from '$lib/utils/routes';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async () => {
-	// Get the reset token from query string
-	// Handle both ?reset_password_token= and hash-based query strings
+	// The app is hash-routed, so the reset link may carry the token in the real
+	// query string or inside the hash (`#/users/resetpassword?reset_password_token=`).
 	const searchParams = new URLSearchParams(
 		window.location.search || window.location.hash.split('?')[1] || ''
 	);

--- a/packages/map-next/src/routes/users/sign-in/+page.svelte
+++ b/packages/map-next/src/routes/users/sign-in/+page.svelte
@@ -22,7 +22,6 @@
 			const response = await signIn(values);
 			if (response.user?.email === values.email) {
 				toastSuccess(m.user_onboarding_sign_in_success({ username: response.user.name }));
-				// Success - close modal and redirect
 				const targetUrl = getRedirectUrl(page);
 				await goto(targetUrl);
 			}


### PR DESCRIPTION
Two passes over `packages/map-next`, one per commit.

**Comment deslop.** Strips comments that narrate the code they sit above, restate a signature, or record changelog entries — the largest block being 34 `/** Color for X areas. */` docstrings above `x: map[400]` in `map-style.ts`, plus SvelteKit template stubs in `app.d.ts`, section banners in `Map`/`MapSidebar`/`+layout`, and the enumerated "This script: 1. 2. 3." headers in the build scripts. Where narration was hiding a real rationale — the auth-modal collapse effect, the reset-token hash fallback, the `map.css` rename — the comment was rewritten to state the *why* rather than dropped. Vendored `src/lib/components/ui/**` (shadcn-svelte) and the `e2e/` comments were left alone.

**Profile unification.** `FarmProfile` (319 lines) and `InitiativeProfile` (275) were ~85% the same file — identical superform setup, drawer header, read/edit switch, save-bar error mapping, sticky cancel/save, share action and contact CTA. That scaffolding moves into a new `EntryProfile`, which owns the form and passes it to `editSections`/`readSections` snippets; the two originals keep their public props and shrink to 120 and 59 lines, so `MapSidebar` is unchanged. Layout drift is resolved along the way: initiatives adopt the farm's `p-2` header and footer padding, and the `divide-y` farms drew between edit-mode sections is dropped so both types match read mode, which has never drawn dividers — restoring the read/edit divider-rhythm parity the section comment claims (F4.2).

Verified on both commits: `svelte-check` 0 errors, `eslint` clean, 130 unit tests, and the full 87-test Playwright suite — including the two `edit-parity` tests that assert read-vs-edit section-heading sequences per entry type.

Still open from the deslop pass and **not** addressed here: the 1012-line `MapSidebar` god component, the stubbed `search-widget`, and several implementation-coupled tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)