### PR TITLE
feat(embed): Consistent map popups (tooltips)

### DIFF
--- a/packages/embed/e2e/depot-on-profile.test.ts
+++ b/packages/embed/e2e/depot-on-profile.test.ts
@@ -416,41 +416,6 @@ test('a depot row is collapsed by default and expands to reveal description, web
 	await expect(sparseCard).not.toContainText('Mon, Wed');
 });
 
-test('expanding a depot row surfaces its address in the map popup', async ({ page }) => {
-	const depot: DepotSeed = {
-		id: 'depot-details',
-		name: 'Detail Depot',
-		farmId: 'farm-details',
-		farmName: 'Details Farm'
-	};
-
-	await page.route(/\/entries(?:\/)?(?:\?.*)?$/, (route) =>
-		fulfillJson(route, {
-			type: 'FeatureCollection',
-			features: [buildFarmSummary('farm-details', 'Details Farm')]
-		})
-	);
-
-	await page.route(/\/farms\/farm-details(?:\/)?(?:\?.*)?$/, (route) =>
-		fulfillJson(route, buildFarmDetail('farm-details', 'Details Farm', [depot]))
-	);
-
-	await page.goto('/#/farms/farm-details');
-
-	const card = page.locator('[data-testid="depot-card"][data-depot-id="depot-details"]');
-	await expect(card).toBeVisible({ timeout: 15000 });
-
-	// The row still hides the street address; expanding then selecting must make
-	// it reachable in the map popup (buildDepotFeature seeds it).
-	await card.getByRole('button', { name: /Detail Depot/ }).click();
-	await card.getByTestId('depot-card-select').click();
-
-	const popup = page.locator('.maplibregl-popup-content');
-	await expect(popup).toBeVisible({ timeout: 15000 });
-	await expect(popup).toContainText('Bahnhofstrasse 1');
-	await expect(popup).toContainText('Mon, Wed');
-});
-
 test('my-entries groups a cross-owned depot under the foreign farm with an ownership hint', async ({
 	page
 }) => {

--- a/packages/embed/src/lib/components/domain/farms/FarmProfile.svelte
+++ b/packages/embed/src/lib/components/domain/farms/FarmProfile.svelte
@@ -30,6 +30,8 @@
 		onDepotEdit?: (depot: DepotFeature) => void;
 		onDepotDelete?: (depot: DepotFeature) => void;
 		onAddDepot?: () => void;
+		/** Depot id to expand in the depot list (driven by map marker clicks). */
+		selectedDepotId?: string | null;
 	}
 
 	let {
@@ -45,7 +47,8 @@
 		onDepotSelect,
 		onDepotEdit,
 		onDepotDelete,
-		onAddDepot
+		onAddDepot,
+		selectedDepotId
 	}: FarmProfileProps = $props();
 
 	const products = $derived(editorData?.products ?? []);
@@ -95,6 +98,7 @@
 			properties={farmProperties(properties)}
 			{ownedDepotIds}
 			isFarmOwner={canEdit}
+			{selectedDepotId}
 			{onDepotSelect}
 			{onDepotEdit}
 			{onDepotDelete}
@@ -111,6 +115,7 @@
 			properties={farmProperties(properties)}
 			{ownedDepotIds}
 			isFarmOwner={canEdit}
+			{selectedDepotId}
 			{onDepotSelect}
 			{onDepotEdit}
 			{onDepotDelete}

--- a/packages/embed/src/lib/components/domain/farms/sections/FarmDepotsSection.svelte
+++ b/packages/embed/src/lib/components/domain/farms/sections/FarmDepotsSection.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { untrack } from 'svelte';
 	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
 	import ChevronUpIcon from '@lucide/svelte/icons/chevron-up';
 	import ExternalLinkIcon from '@lucide/svelte/icons/external-link';
@@ -17,6 +18,8 @@
 		ownedDepotIds?: ReadonlySet<string>;
 		/** Whether the signed-in user owns this farm (drives "add pickup location"). */
 		isFarmOwner?: boolean;
+		/** Depot id to expand and scroll to (driven by map marker clicks). */
+		selectedDepotId?: string | null;
 		onDepotSelect?: (depot: DepotFeature) => void;
 		onDepotEdit?: (depot: DepotFeature) => void;
 		onDepotDelete?: (depot: DepotFeature) => void;
@@ -27,6 +30,7 @@
 		properties,
 		ownedDepotIds = new Set<string>(),
 		isFarmOwner = false,
+		selectedDepotId = null,
 		onDepotSelect,
 		onDepotEdit,
 		onDepotDelete,
@@ -36,6 +40,26 @@
 	const depotFeatures = $derived<Feature<Point, DepotProperties>[]>(
 		properties?.depots?.features ?? []
 	);
+
+	let openItems = $state<string[]>([]);
+	// Proxy returns null for unset keys so bind:ref never receives undefined.
+	let depotItemEls: Record<string, HTMLElement | null> = new Proxy(
+		{} as Record<string, HTMLElement | null>,
+		{ get: (t, k: string) => (k in t ? t[k] : null) }
+	);
+
+	$effect(() => {
+		if (!selectedDepotId) return;
+		const current = untrack(() => openItems);
+		if (!current.includes(selectedDepotId)) {
+			openItems = [...current, selectedDepotId];
+		}
+		depotItemEls[selectedDepotId]?.scrollIntoView({
+			behavior: 'smooth',
+			block: 'end',
+			inline: 'nearest'
+		});
+	});
 
 	function formatDepotPlace(depot: DepotProperties): string {
 		return [depot.postalcode, depot.city].filter(Boolean).join(' ');
@@ -62,12 +86,17 @@
 			{/if}
 		</div>
 		{#if depotFeatures.length > 0}
-			<Accordion.Root type="multiple" class="rounded-xl border border-separator bg-card shadow-sm">
+			<Accordion.Root
+				type="multiple"
+				bind:value={openItems}
+				class="rounded-xl border border-separator bg-card shadow-sm"
+			>
 				{#each depotFeatures as depot (depot.properties.id)}
 					{@const isOwned = ownedDepotIds.has(depot.properties.id)}
 					{@const place = formatDepotPlace(depot.properties)}
 					{@const websiteUrl = safeHttpUrl(depot.properties.url)}
 					<Accordion.Item
+						bind:ref={depotItemEls[depot.properties.id]}
 						value={depot.properties.id}
 						data-testid="depot-card"
 						data-depot-id={depot.properties.id}

--- a/packages/embed/src/lib/components/domain/map/EntryMarkerButton.svelte
+++ b/packages/embed/src/lib/components/domain/map/EntryMarkerButton.svelte
@@ -54,8 +54,8 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		width: 45px;
-		height: 45px;
+		width: 40px;
+		height: 40px;
 		cursor: pointer;
 		--marker-drop-shadow: drop-shadow(0 2px 5px var(--map-network-line));
 	}

--- a/packages/embed/src/lib/components/domain/map/NetworkLayer.svelte
+++ b/packages/embed/src/lib/components/domain/map/NetworkLayer.svelte
@@ -110,8 +110,8 @@
 			'circle-radius': [
 				'case',
 				['get', 'selected'],
-				circleBaseRadius * 1.25,
-				circleBaseRadius * 1.5
+				circleBaseRadius * 1.75,
+				circleBaseRadius * 1.25
 			],
 			'circle-color': theme.networkLineColor,
 			'circle-pitch-alignment': 'map'
@@ -123,7 +123,12 @@
 		id="farm-network-depot-fill"
 		beforeId={BEFORE_ID}
 		paint={{
-			'circle-radius': ['case', ['get', 'selected'], circleBaseRadius, circleBaseRadius * 0.75],
+			'circle-radius': [
+				'case',
+				['get', 'selected'],
+				circleBaseRadius * 0.8,
+				circleBaseRadius * 0.5
+			],
 			'circle-color': theme.secondaryPlaceColor,
 			'circle-opacity': 0.95,
 			'circle-pitch-alignment': 'map'
@@ -147,9 +152,9 @@
 
 <style>
 	.marker-icon {
-		width: 55px;
-		height: 55px;
-		padding: 5px;
+		width: 60px;
+		height: 60px;
+		padding: 10px;
 		border-radius: 50%;
 		background: var(--map-network-line);
 	}

--- a/packages/embed/src/lib/components/domain/map/Popup.svelte
+++ b/packages/embed/src/lib/components/domain/map/Popup.svelte
@@ -3,7 +3,7 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import type { DepotProperties, EntryFeature } from '$lib/types/entries';
 
-	const MARKER_OFFSET = 20;
+	const MARKER_OFFSET = 18;
 
 	interface PopupSelectedEntry {
 		feature?: EntryFeature;
@@ -55,53 +55,29 @@
 	offset={[offset[0], offset[1] - MARKER_OFFSET]}
 	anchor="bottom"
 	closeOnClickOutside={true}
-	maxWidth="250px"
+	maxWidth="200px"
 	{onclose}
 >
-	<div class="entry-popup">
-		<div class="flex min-w-0 flex-col gap-0.5">
-			<span class="truncate font-medium text-card-foreground">{feature?.properties.name}</span>
-			{#if depot}
-				{#if depotAddress}
-					<span class="text-muted-foreground">{depotAddress}</span>
-				{:else}
-					<span class="truncate text-muted-foreground">{depot.city}</span>
-				{/if}
-				{#if depot.deliveryDays}
-					<span class="text-muted-foreground">
-						{m.editor_depot_field_delivery_days()}: {depot.deliveryDays}
-					</span>
-				{/if}
-			{:else}
-				<span class="truncate text-muted-foreground">
-					{feature?.properties.city}
-				</span>
-			{/if}
-		</div>
-	</div>
+	<div class="truncate font-medium">{feature?.properties.name}</div>
 </Popup>
 
 <style>
-	.entry-popup {
-		display: flex;
-		align-items: center;
-		gap: 0.25rem;
-		padding: 0rem 0.25rem;
-	}
-
 	/*
 	 * Restyle the MapLibre popup as a flat card (spec F13): card background/
 	 * foreground tokens, the app radius scale, and a restrained shadow —
 	 * replacing the previous 0.8-opacity dark box. Works in every theme.
 	 */
+	:global(.map .maplibregl-popup) {
+		opacity: 0.9;
+	}
 	:global(.map .maplibregl-popup-content) {
-		background: var(--card);
-		color: var(--card-foreground);
-		border-radius: var(--radius);
-		box-shadow: 0 4px 12px color-mix(in srgb, var(--foreground) 15%, transparent);
+		background: var(--color-map-popup);
+		color: var(--color-map-popup-foreground);
+		border-radius: 0.5em;
+		padding: 0.5em 1em;
 	}
 	:global(.map .maplibregl-popup-anchor-bottom .maplibregl-popup-tip) {
-		border-top-color: var(--card);
+		border-top-color: var(--color-map-popup);
 	}
 	:global(.map .maplibregl-popup-close-button) {
 		color: var(--muted-foreground);

--- a/packages/embed/src/lib/components/domain/map/Popup.svelte
+++ b/packages/embed/src/lib/components/domain/map/Popup.svelte
@@ -54,7 +54,6 @@
 	{lngLat}
 	offset={[offset[0], offset[1] - MARKER_OFFSET]}
 	anchor="bottom"
-	closeOnClickOutside={true}
 	maxWidth="200px"
 	{onclose}
 >

--- a/packages/embed/src/lib/design/theme-vars.css
+++ b/packages/embed/src/lib/design/theme-vars.css
@@ -50,6 +50,7 @@
 	--base-color-amber-900: oklch(0.415 0.062 55);
 	--base-color-scrim: oklch(0 0 0 / 30%);
 	--base-color-map-popup: oklch(0.267 0.052 194.7);
+	--base-color-map-popup-foreground: var(--base-color-white);
 	--base-color-map-base: #266050;
 	--base-color-map-place-primary: #ffa08c;
 	--base-color-map-place-secondary: #ffc8af;
@@ -89,6 +90,7 @@
 	--map-font-regular: var(--base-font-roboto-regular);
 	--map-font-bold: var(--base-font-roboto-bold);
 	--map-popup: var(--base-color-map-popup);
+	--map-popup-foreground: var(--base-color-map-popup-foreground);
 
 	/* shadcn tokens */
 	--radius: var(--base-radius);
@@ -223,6 +225,7 @@
 	--map-font-regular: var(--base-font-roboto-regular);
 	--map-font-bold: var(--base-font-roboto-bold);
 	--map-popup: var(--base-color-map-popup);
+	--map-popup-foreground: var(--base-color-map-popup-foreground);
 
 	/* shadcn tokens */
 	--radius: var(--base-radius);

--- a/packages/embed/src/lib/stores/entry-selection.svelte.ts
+++ b/packages/embed/src/lib/stores/entry-selection.svelte.ts
@@ -88,8 +88,12 @@ export function createEntrySelection(sources: EntrySelectionSources): EntrySelec
 						);
 
 					if (associatedFarmFeature) {
-						sources.onEntryClick?.(associatedFarmFeature as EntryFeature, { openPopup: true });
-						// Prevent duplicate pan when the detail route data resolves for this farm.
+						// Only pan to the farm on first selection; skip if its network is already open.
+						if (sources.focusedEntry()?.properties.id !== farmId) {
+							sources.onEntryClick?.(associatedFarmFeature as EntryFeature, { openPopup: true });
+						} else {
+							sources.onEntryClick?.(feature, { openPopup: true });
+						}
 						lastDetailId = farmId;
 					}
 					await goto(routeBuilders.farm.detail(farmId));

--- a/packages/embed/src/routes/Map.svelte
+++ b/packages/embed/src/routes/Map.svelte
@@ -49,6 +49,7 @@
 
 	interface EntryFocusOptions {
 		offset?: [number, number];
+		openPopup?: boolean;
 	}
 
 	const BBOX_SYNC_DEBOUNCE_MS = 100;
@@ -119,8 +120,11 @@
 		feature: EntryFeature;
 		options?: EntryFocusOptions;
 	} | null = $state(null);
+	let popupEntry: {
+		feature: EntryFeature;
+		options?: { offset?: [number, number] };
+	} | null = $state(null);
 	let isPopupOpen = $state(false);
-	let isHoverPopupOpen = $state(false);
 	let currentZoom: number = $state(initialZoom);
 	let selectedCountry = $state(country);
 	let selectedState: string | null = $state(null);
@@ -303,7 +307,7 @@
 		}
 
 		selectedEntry = null;
-		isPopupOpen = false;
+		clearPopup();
 		pendingFocus = null;
 		pendingDiscoveryFocus = null;
 
@@ -330,7 +334,7 @@
 
 		selectedEntry = { feature, options };
 		if (options?.openPopup) {
-			isPopupOpen = true;
+			showPopup(feature, options);
 		}
 
 		// A farm with depots is framed by the network `fitBounds` effect; issuing a
@@ -426,7 +430,7 @@
 		// Close the map popup when the detail view is closed. Note this also fires on
 		// popup dismissal while the profile stays open, so it must NOT clear the depot
 		// selection — that is done on the actual profile close (MapSidebar).
-		isPopupOpen = false;
+		clearPopup();
 		selectedEntry = null;
 		pendingFocus = null;
 	}
@@ -456,13 +460,8 @@
 			networkSelection.selectDepot(entry.properties.id);
 		}
 
-		focusEntry(entry, options);
+		focusEntry(entry, { ...options, openPopup: true });
 		sidebarComponent?.openDetailView(entry);
-
-		// Open the popup after a short delay to let the map start moving
-		setTimeout(() => {
-			isPopupOpen = true;
-		}, 100);
 	}
 
 	function syncSidebarEntriesToViewport() {
@@ -568,51 +567,38 @@
 	});
 
 	let hoveredDepotFeatureId: string | null = $state(null);
-	let hoverPopupEntry: {
-		feature: EntryFeature;
-		lngLat: [number, number];
-		options?: { offset?: [number, number]; lngLat?: [number, number] };
-	} | null = $state(null);
 
 	const circleBaseRadius = $derived(currentZoom * 0.75);
 	const layerOpacity = $derived(networkEntry ? 0.5 : 1);
 	const showSidebar = $derived(!isInternalDesignRouteHash(page.url.hash));
 
-	function showHoverPopup(feature: EntryFeature, options?: { offset?: [number, number] }) {
-		const lngLat = [feature.geometry.coordinates[0], feature.geometry.coordinates[1]] as [
-			number,
-			number
-		];
-		hoverPopupEntry = {
-			feature,
-			lngLat,
-			options
-		};
-		isHoverPopupOpen = true;
-		if (feature.properties.type === 'Depot') {
-			hoveredDepotFeatureId = feature.properties.id;
-		}
+	function showPopup(feature: EntryFeature, options?: { offset?: [number, number] }) {
+		popupEntry = { feature, options };
+		isPopupOpen = true;
+		hoveredDepotFeatureId = feature.properties.type === 'Depot' ? feature.properties.id : null;
 	}
 
-	function clearHoverPopup() {
-		hoverPopupEntry = null;
-		isHoverPopupOpen = false;
+	function clearPopup() {
+		popupEntry = null;
+		isPopupOpen = false;
 		hoveredDepotFeatureId = null;
 	}
 
-	// Resolves the hovered circle-layer feature to an entry and shows the popup.
-	// Clusters are resolved to their first leaf so the popup shows real content.
+	function handlePopupClose() {
+		clearPopup();
+	}
+
 	async function handleCircleLayerHover(
 		sourceId: string,
 		feature: Feature<Geometry, GeoJsonProperties> | undefined
 	) {
-		if (!feature || feature.geometry.type !== 'Point') {
-			clearHoverPopup();
+		if (!feature) {
+			clearPopup();
 			return;
 		}
 		const entry = asEntryFeature(feature);
 		if (entry) {
-			showHoverPopup(entry);
+			showPopup(entry);
 			return;
 		}
 		const clusterId = feature.properties?.cluster_id;
@@ -621,7 +607,7 @@
 		if (!source?.getClusterLeaves) return;
 		const leaves = await source.getClusterLeaves(clusterId, 1, 0);
 		const first = asEntryFeature(leaves[0]);
-		if (first) showHoverPopup(first);
+		if (first) showPopup(first);
 	}
 
 	function handleMapMarkerHover(
@@ -629,10 +615,10 @@
 		options?: { offset?: [number, number] }
 	) {
 		if (!feature) {
-			clearHoverPopup();
+			clearPopup();
 			return;
 		}
-		showHoverPopup(feature, options);
+		showPopup(feature, options);
 	}
 
 	function isEditableTarget(target: EventTarget | null): boolean {
@@ -719,7 +705,6 @@
 					minzoom={zoom.min}
 					onclick={(e) => handleMapEntryClick(e.features?.[0])}
 					onmousemove={(e) => handleCircleLayerHover('secondary-places', e.features?.[0])}
-					onmouseleave={clearHoverPopup}
 				/>
 			</GeoJSON>
 
@@ -738,7 +723,6 @@
 					maxzoom={9.5}
 					onclick={(e) => handleMapEntryClick(e.features?.[0])}
 					onmousemove={(e) => handleCircleLayerHover('primary-places', e.features?.[0])}
-					onmouseleave={clearHoverPopup}
 				/>
 				<CircleLayer
 					id="primary-points"
@@ -753,13 +737,11 @@
 					maxzoom={9.5}
 					onclick={(e) => handleMapEntryClick(e.features?.[0])}
 					onmousemove={(e) => handleCircleLayerHover('primary-places', e.features?.[0])}
-					onmouseleave={clearHoverPopup}
 				/>
 
 				<SymbolMarkerLayer
 					onMarkerClick={handleMapEntryClick}
 					onMarkerHover={handleMapMarkerHover}
-					onMarkerLeave={clearHoverPopup}
 					minzoom={9.5}
 					highlightedIds={highlightedNetworkIds}
 					selectedKey={selectedEntryKey}
@@ -775,7 +757,6 @@
 					{circleBaseRadius}
 				/>
 			{/if}
-
 			{#if hoveredDepotFeatureId}
 				<GeoJSON id="secondary-hovered-point-overlay" data={secondaryPlaces}>
 					<CircleLayer
@@ -793,11 +774,8 @@
 				</GeoJSON>
 			{/if}
 
-			{#if selectedEntry}
-				<Popup bind:isPopupOpen {selectedEntry} onclose={handleDetailClose} />
-			{/if}
-			{#if hoverPopupEntry}
-				<Popup bind:isPopupOpen={isHoverPopupOpen} selectedEntry={hoverPopupEntry} />
+			{#if popupEntry}
+				<Popup bind:isPopupOpen selectedEntry={popupEntry} onclose={handlePopupClose} />
 			{/if}
 		</MapLibre>
 	{/if}

--- a/packages/embed/src/routes/Map.svelte
+++ b/packages/embed/src/routes/Map.svelte
@@ -53,7 +53,7 @@
 
 	const BBOX_SYNC_DEBOUNCE_MS = 100;
 	const FOCUS_DURATION_MS = 1000;
-	const REGION_FOCUS_PADDING_PX = 64;
+	const REGION_FOCUS_PADDING_PX = 80;
 	// Tailwind `lg` breakpoint: the editor drawer only widens at/above this width
 	// (see SidebarShell's `lg:w-[var(--map-editor-width)]`).
 	const LG_BREAKPOINT_PX = 1024;

--- a/packages/embed/src/routes/MapSidebar.svelte
+++ b/packages/embed/src/routes/MapSidebar.svelte
@@ -354,6 +354,7 @@
 				onDepotEdit={handleDepotEditFromProfile}
 				onDepotDelete={entryActions.deleteDepotFromProfile}
 				onAddDepot={handleAddDepotFromProfile}
+				selectedDepotId={networkSelection.selectedDepotId}
 			/>
 		{/key}
 	{:else if view.isInitiativeEditor && editorData}
@@ -400,6 +401,7 @@
 				onDepotEdit={handleDepotEditFromProfile}
 				onDepotDelete={entryActions.deleteDepotFromProfile}
 				onAddDepot={handleAddDepotFromProfile}
+				selectedDepotId={networkSelection.selectedDepotId}
 			/>
 		{/key}
 	{:else if view.isInitiativeDetail && detailData}

--- a/packages/embed/src/routes/MapSidebar.svelte.spec.ts
+++ b/packages/embed/src/routes/MapSidebar.svelte.spec.ts
@@ -249,7 +249,7 @@ describe('MapSidebar', () => {
 		await expect.poll(() => onEntryClick.mock.calls.length).toBe(2);
 		await expect.poll(() => gotoMock.mock.calls.length).toBe(1);
 		expect(gotoMock.mock.calls[0]?.[0]).toBe('#/farms/farm-a');
-		expect(onEntryClick.mock.calls[1]?.[0]?.properties?.id).toBe('farm-a');
+		expect(onEntryClick.mock.calls[1]?.[0]?.properties?.id).toBe('depot-1');
 	});
 
 	it('openDetailView in my-entries scope does not trigger a second pan when triggerPan is false', async () => {

--- a/packages/embed/src/routes/layout.css
+++ b/packages/embed/src/routes/layout.css
@@ -108,6 +108,7 @@
 	--color-map-place-primary: var(--map-place-primary);
 	--color-map-place-secondary: var(--map-place-secondary);
 	--color-map-popup: var(--map-popup);
+	--color-map-popup-foreground: var(--map-popup-foreground);
 	--font-map-regular: var(--map-font-regular);
 	--font-map-bold: var(--map-font-bold);
 }


### PR DESCRIPTION
Redesign/refactoring of of map popups (tooltips):

- [x] Make map popup styling consistently with map design
- [x] More consistent behavior of tooltips between farms, initiatives, and depots
- [x] Remove address line from popups (less clutter – address is shown in sidebar anyways)
- [x] Show map tooltip when depot is selected in sidebar, and vice versa