### PR TITLE
feat(embed): Full search widget implementation

### DIFF
--- a/packages/embed/src/lib/components/domain/map/MapSidebarHeader.svelte
+++ b/packages/embed/src/lib/components/domain/map/MapSidebarHeader.svelte
@@ -24,9 +24,6 @@
 		selectedState: string | null;
 		onOpenAllEntriesScope: () => void;
 		onOpenMyEntriesScope: () => void;
-		onSearchSuggestionSelect: (suggestion: AutocompleteSuggestion) => void | Promise<void>;
-		onSearchFocus?: () => void;
-		onSearchBlur?: () => void;
 		onCountrySelect: (countryCode: string) => void;
 		onStateSelect?: (stateCode: string | null) => void;
 	}
@@ -46,9 +43,6 @@
 		selectedState,
 		onOpenAllEntriesScope,
 		onOpenMyEntriesScope,
-		onSearchSuggestionSelect,
-		onSearchFocus,
-		onSearchBlur,
 		onCountrySelect,
 		onStateSelect
 	}: Props = $props();
@@ -93,9 +87,6 @@
 			isLoading={isSearchLoading}
 			open={showSearchSuggestions}
 			disabled={isMyEntriesScope}
-			onSelect={onSearchSuggestionSelect}
-			onFocus={onSearchFocus}
-			onBlur={onSearchBlur}
 		/>
 	</div>
 	{#if !collapsed && !isMyEntriesScope}

--- a/packages/embed/src/lib/components/domain/map/SearchCommand.stories.svelte
+++ b/packages/embed/src/lib/components/domain/map/SearchCommand.stories.svelte
@@ -24,30 +24,28 @@
 		{ id: 'depot-central', title: 'Central Depot', type: 'depot' },
 		{ id: 'init-food', title: 'Food Coop Initiative', type: 'initiative' }
 	];
-
-	const noop = () => {};
 </script>
 
 <Story name="Grouped Results" asChild>
 	<div class="w-sm pb-72">
-		<SearchCommand searchValue="be" {suggestions} open onSelect={noop} />
+		<SearchCommand searchValue="be" {suggestions} open />
 	</div>
 </Story>
 
 <Story name="Loading" asChild>
 	<div class="w-sm pb-24">
-		<SearchCommand searchValue="be" suggestions={[]} open isLoading onSelect={noop} />
+		<SearchCommand searchValue="be" suggestions={[]} open isLoading />
 	</div>
 </Story>
 
 <Story name="Empty" asChild>
 	<div class="w-sm pb-24">
-		<SearchCommand searchValue="xyz" suggestions={[]} open onSelect={noop} />
+		<SearchCommand searchValue="xyz" suggestions={[]} open />
 	</div>
 </Story>
 
 <Story name="Closed" asChild>
 	<div class="w-sm">
-		<SearchCommand searchValue="" {suggestions} onSelect={noop} />
+		<SearchCommand searchValue="" {suggestions} />
 	</div>
 </Story>

--- a/packages/embed/src/lib/components/domain/map/SearchCommand.svelte
+++ b/packages/embed/src/lib/components/domain/map/SearchCommand.svelte
@@ -4,6 +4,7 @@
 	import { getPlaceIcon } from '$lib/utils/marker-icons';
 	import type { AutocompleteSuggestion, AutocompleteSuggestionType } from '$lib/api/discovery';
 	import { cn } from '$lib/utils/tailwind';
+	import { routeBuilders } from '$lib/utils/routes';
 	import * as m from '$lib/paraglide/messages.js';
 
 	interface Props {
@@ -14,11 +15,9 @@
 		open?: boolean;
 		disabled?: boolean;
 		placeholder?: string;
+		prefix?: string;
 		/** Bound so higher layers can focus the input (keyboard shortcut, mobile). */
 		inputEl?: HTMLInputElement | null;
-		onSelect: (suggestion: AutocompleteSuggestion) => void | Promise<void>;
-		onFocus?: () => void;
-		onBlur?: () => void;
 	}
 
 	let {
@@ -28,10 +27,8 @@
 		open = false,
 		disabled = false,
 		placeholder = m.map_sidebar_search_placeholder(),
-		inputEl = $bindable(null),
-		onSelect,
-		onFocus,
-		onBlur
+		prefix = '',
+		inputEl = $bindable(null)
 	}: Props = $props();
 
 	// Grouped, icon-labelled sections in a fixed order (Locations first, matching
@@ -68,6 +65,17 @@
 			dismissed = true;
 		}
 	}
+
+	function hrefForSuggestion(suggestion: AutocompleteSuggestion): string {
+		const route = {
+			location: routeBuilders.discovery.location(suggestion.id),
+			farm: routeBuilders.farm.detail(suggestion.id),
+			depot: routeBuilders.depotLegacy.detail(suggestion.id),
+			initiative: routeBuilders.initiative.detail(suggestion.id)
+		}[suggestion.type];
+
+		return `${prefix}${route}`;
+	}
 </script>
 
 <Command.Root shouldFilter={false} class="relative w-full overflow-visible bg-transparent">
@@ -79,8 +87,6 @@
 		aria-label={placeholder}
 		wrapperClass="h-9 rounded-4xl border border-transparent bg-input/50 max-md:h-11 focus-within:border-ring"
 		onkeydown={handleKeydown}
-		onfocus={onFocus}
-		onblur={onBlur}
 	/>
 	{#if panelOpen}
 		<Command.List
@@ -106,9 +112,9 @@
 				{#each grouped as group (group.type)}
 					<Command.Group heading={group.heading()}>
 						{#each group.items as suggestion (`${suggestion.type}-${suggestion.id}`)}
-							<Command.Item
+							<Command.LinkItem
 								value={`${suggestion.type}-${suggestion.id}`}
-								onSelect={() => void onSelect(suggestion)}
+								href={hrefForSuggestion(suggestion)}
 								onpointerdown={(event) => event.preventDefault()}
 							>
 								{#if group.type === 'location'}
@@ -121,7 +127,7 @@
 									/>
 								{/if}
 								<span class="line-clamp-1">{suggestion.title}</span>
-							</Command.Item>
+							</Command.LinkItem>
 						{/each}
 					</Command.Group>
 				{/each}

--- a/packages/embed/src/lib/components/domain/map/SlimSearchHeader.svelte
+++ b/packages/embed/src/lib/components/domain/map/SlimSearchHeader.svelte
@@ -13,9 +13,6 @@
 		showSearchSuggestions?: boolean;
 		searchInputEl?: HTMLInputElement | null;
 		onBack: () => void;
-		onSearchSuggestionSelect: (suggestion: AutocompleteSuggestion) => void | Promise<void>;
-		onSearchFocus?: () => void;
-		onSearchBlur?: () => void;
 	}
 
 	let {
@@ -24,10 +21,7 @@
 		isLoading = false,
 		showSearchSuggestions = false,
 		searchInputEl = $bindable(null),
-		onBack,
-		onSearchSuggestionSelect,
-		onSearchFocus,
-		onSearchBlur
+		onBack
 	}: Props = $props();
 </script>
 
@@ -47,9 +41,6 @@
 			{suggestions}
 			{isLoading}
 			open={showSearchSuggestions}
-			onSelect={onSearchSuggestionSelect}
-			onFocus={onSearchFocus}
-			onBlur={onSearchBlur}
 		/>
 	</div>
 </Sidebar.Header>

--- a/packages/embed/src/lib/components/ui/command/command-link-item.svelte
+++ b/packages/embed/src/lib/components/ui/command/command-link-item.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { Command as CommandPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils/tailwind.js';
+
+	let { class: className, ...restProps }: CommandPrimitive.LinkItemProps = $props();
+</script>
+
+<CommandPrimitive.LinkItem
+	class={cn(
+		"relative flex cursor-default items-center gap-2 rounded-md px-2 py-2 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+		className
+	)}
+	{...restProps}
+/>

--- a/packages/embed/src/lib/components/ui/command/index.ts
+++ b/packages/embed/src/lib/components/ui/command/index.ts
@@ -3,6 +3,7 @@ import Empty from './command-empty.svelte';
 import Group from './command-group.svelte';
 import Input from './command-input.svelte';
 import Item from './command-item.svelte';
+import LinkItem from './command-link-item.svelte';
 import List from './command-list.svelte';
 import Loading from './command-loading.svelte';
 import Separator from './command-separator.svelte';
@@ -13,6 +14,7 @@ export {
 	Group,
 	Input,
 	Item,
+	LinkItem,
 	List,
 	Loading,
 	Separator,

--- a/packages/embed/src/routes/MapSidebar.svelte
+++ b/packages/embed/src/routes/MapSidebar.svelte
@@ -306,16 +306,12 @@
 		isLoading={search.isLoading}
 		showSearchSuggestions={search.showSuggestions}
 		onBack={handleDetailBack}
-		onSearchSuggestionSelect={search.selectSuggestion}
-		onSearchFocus={search.handleFocus}
-		onSearchBlur={search.handleBlur}
 	/>
 {/snippet}
 
 <SidebarShell
 	bind:collapsed={() => collapse.collapsed, (value) => (collapse.collapsed = value)}
 	mode={view.shellMode}
-	raiseToFull={isMobile.current && search.isFocused}
 >
 	{#if view.isNavigatingToDataRoute}
 		<ProfileSkeleton />
@@ -431,9 +427,6 @@
 			{selectedState}
 			onOpenAllEntriesScope={handleOpenAllEntriesScope}
 			onOpenMyEntriesScope={handleOpenMyEntriesScope}
-			onSearchSuggestionSelect={search.selectSuggestion}
-			onSearchFocus={search.handleFocus}
-			onSearchBlur={search.handleBlur}
 			onCountrySelect={handleCountrySelect}
 			onStateSelect={onStateChange}
 		/>

--- a/packages/embed/src/widgets/search-widget/index.ts
+++ b/packages/embed/src/widgets/search-widget/index.ts
@@ -1,5 +1,5 @@
 import SearchWidget from './search-widget.svelte';
-import '$lib/design/theme-vars.css';
+import '../../routes/layout.css';
 import { mount, unmount } from 'svelte';
 import type { SearchWidgetProps } from './search-widget.svelte';
 

--- a/packages/embed/src/widgets/search-widget/search-widget.svelte
+++ b/packages/embed/src/widgets/search-widget/search-widget.svelte
@@ -6,64 +6,92 @@
 </script>
 
 <script lang="ts">
-	/**
-	 * A simple search widget that can be embedded in external pages.
-	 * This is a placeholder implementation - extend with actual search functionality.
-	 */
+	import SearchCommand from '$lib/components/domain/map/SearchCommand.svelte';
+	import { getAutocompleteSuggestions, type AutocompleteSuggestion } from '$lib/api/discovery';
+	import config from '$lib/config/app-configuration';
+	import { routeBuilders } from '$lib/utils/routes';
 
-	let { placeholder = 'Search...', apiBaseUrl = '' }: SearchWidgetProps = $props();
+	const MIN_SEARCH_CHARS = 2;
+	const SEARCH_DEBOUNCE_MS = 300;
 
-	let searchQuery = $state('');
+	let { placeholder = 'Search...', apiBaseUrl: _apiBaseUrl = '' }: SearchWidgetProps = $props();
 
-	function handleSubmit(event: Event) {
-		event.preventDefault();
-		// TODO: Implement actual search functionality
-		console.log('Search submitted:', searchQuery, 'API:', apiBaseUrl);
+	let searchValue = $state('');
+	let suggestions = $state<AutocompleteSuggestion[]>([]);
+	let isLoading = $state(false);
+	let latestRequestId = 0;
+
+	async function loadSuggestions(query: string) {
+		const requestId = ++latestRequestId;
+		isLoading = true;
+
+		try {
+			const result = await getAutocompleteSuggestions({
+				text: query,
+				locale: config.displayLocale,
+				withEntries: true
+			});
+			if (requestId === latestRequestId) {
+				suggestions = result;
+			}
+		} catch {
+			if (requestId === latestRequestId) {
+				suggestions = [];
+			}
+		} finally {
+			if (requestId === latestRequestId) {
+				isLoading = false;
+			}
+		}
 	}
+
+	$effect(() => {
+		const query = searchValue.trim();
+		if (query.length < MIN_SEARCH_CHARS) {
+			latestRequestId += 1;
+			suggestions = [];
+			isLoading = false;
+			return;
+		}
+
+		isLoading = true;
+		const timeout = setTimeout(() => void loadSuggestions(query), SEARCH_DEBOUNCE_MS);
+		return () => clearTimeout(timeout);
+	});
+
+	function handleSelect(suggestion: AutocompleteSuggestion) {
+		const routes = {
+			location: routeBuilders.discovery.location(suggestion.id),
+			farm: routeBuilders.farm.detail(suggestion.id),
+			initiative: routeBuilders.initiative.detail(suggestion.id),
+			depot: routeBuilders.depotLegacy.detail(suggestion.id)
+		};
+		window.location.hash = routes[suggestion.type].slice(1);
+		searchValue = '';
+		suggestions = [];
+		latestRequestId += 1;
+		isLoading = false;
+	}
+
+	const showSuggestions = $derived(searchValue.trim().length >= MIN_SEARCH_CHARS);
+
+	let inputEl = $state<HTMLInputElement | null>(null);
 </script>
 
 <div class="teikei-search-widget">
-	<form onsubmit={handleSubmit} class="teikei-search-form">
-		<input type="search" bind:value={searchQuery} {placeholder} class="teikei-search-input" />
-		<button type="submit" class="teikei-search-button"> Search </button>
-	</form>
+	<SearchCommand
+		bind:searchValue
+		bind:inputEl
+		{suggestions}
+		{isLoading}
+		open={showSuggestions}
+		{placeholder}
+		prefix="/karte/"
+	/>
 </div>
 
 <style>
 	.teikei-search-widget {
 		font-family: var(--font-family-sans);
-	}
-
-	.teikei-search-form {
-		display: flex;
-		gap: 0.5rem;
-	}
-
-	.teikei-search-input {
-		flex: 1;
-		padding: 0.5rem 0.75rem;
-		border: 1px solid var(--color-input);
-		border-radius: var(--radius-md);
-		font-size: 1rem;
-	}
-
-	.teikei-search-input:focus {
-		outline: none;
-		border-color: var(--color-ring);
-		box-shadow: 0 0 0 2px color-mix(in oklch, var(--color-ring) 20%, transparent);
-	}
-
-	.teikei-search-button {
-		padding: 0.5rem 1rem;
-		background-color: var(--color-primary);
-		color: var(--color-primary-foreground);
-		border: none;
-		border-radius: var(--radius-md);
-		font-size: 1rem;
-		cursor: pointer;
-	}
-
-	.teikei-search-button:hover {
-		background-color: var(--color-primary-hover);
 	}
 </style>


### PR DESCRIPTION
Replace the existing `search-widget` placeholder with a functional implementation, based on the `SearchCommand` component used in the map sidebar.

The `search-widget` embed is to be used on the [ErnteTeilen homepage](https://ernte-teilen.org) to "forward" users to the actual map.

- [x] Refactor `SearchCommand` for reusability (make path configurable, use regular HTML links)
- [x] Reuse `SearchComponent` in the `search-widget` embed
